### PR TITLE
chore: bump version to 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1466,7 +1466,7 @@ dependencies = [
 
 [[package]]
 name = "lox"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lox"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Loxone Miniserver CLI — control lights, blinds, and more from your terminal"
 repository = "https://github.com/discostu105/lox"


### PR DESCRIPTION
## Summary
- Bump version to 0.2.1 for bugfix release

https://claude.ai/code/session_01HAtKxGAAuwhnQ26sxHdacW