### PR TITLE
feat: autopilot command for Automatik-Regel rules

### DIFF
--- a/docs/autopilot-design.md
+++ b/docs/autopilot-design.md
@@ -1,0 +1,140 @@
+# Design: `lox autopilot` — Automatik-Regel CLI Support
+
+## Background
+
+Loxone's "Automatik-Regel" (Automatic Rule / Autopilot) feature lets users create
+programmable automation rules via the Loxone app. These rules are stored in the
+Miniserver's `LoxApp3.json` structure file under a top-level `autopilot` key — a
+sibling of `controls`, `rooms`, etc.
+
+Each entry looks like:
+
+```json
+"autopilot": {
+  "<uuid>": {
+    "name": "Turn off lights at midnight",
+    "uuidAction": "<uuid>",
+    "states": {
+      "changed": "<state-uuid>",
+      "history": "<state-uuid>"
+    }
+  }
+}
+```
+
+The Loxone structure file documentation explicitly notes: *"The API isn't publicly
+available."* There is no HTTP command endpoint to trigger or modify rules — they
+are managed exclusively via the app and executed by the Miniserver when conditions
+are met.
+
+`automaticRule` also appears as a **trigger type string** in the history payloads
+of other controls (e.g. a blind moved because an automatic rule fired it). This is
+unrelated to the `autopilot` section itself.
+
+## What We Can Do
+
+| Operation | Feasibility |
+|---|---|
+| List all rules (name, UUID) | ✅ Parse `autopilot` section of structure cache |
+| Show last-fired timestamp | ✅ Read `states.changed` UUID via state API |
+| Show execution history | ⚠️ Format undocumented — deferred |
+| Trigger / activate a rule | ❌ No public API |
+| Create / edit a rule | ❌ App-only |
+
+## CLI Design
+
+### New subcommand: `lox autopilot`
+
+```
+lox autopilot list              # list all automatic rules
+lox autopilot state <name>      # show when a rule last fired
+```
+
+### `autopilot list`
+
+Reads `structure["autopilot"]` from the cached structure file (no extra HTTP calls).
+Prints a table sorted by name:
+
+```
+NAME                                UUID
+Morning blinds                      0abc1234-005c-7471-ffffed57184a0000
+Turn off lights at midnight         0def5678-005c-7471-ffffed57184a0001
+```
+
+With `--json`: full JSON array including state UUIDs.
+
+### `autopilot state <name>`
+
+Resolves `<name>` to a rule via fuzzy substring match (same pattern as control
+resolution). Fetches the `states.changed` UUID via the state API and displays the
+value as a human-readable datetime (the value is a unix timestamp).
+
+```
+Rule:     Turn off lights at midnight
+Last run: 2026-03-08 00:00:03
+```
+
+With `--json`: raw API response.
+
+## Implementation Plan
+
+### `src/client.rs`
+
+Add `AutopilotRule` struct:
+
+```rust
+pub struct AutopilotRule {
+    pub name: String,
+    pub uuid: String,           // uuidAction
+    pub state_changed: String,  // states.changed UUID
+    pub state_history: String,  // states.history UUID
+}
+```
+
+Add `list_autopilot_rules()` method that parses `structure["autopilot"]`. The
+structure key is expected to be a map keyed by UUID (same layout as `controls`).
+
+### `src/main.rs`
+
+Add to `Cmd` enum:
+
+```rust
+/// Manage automatic rules (Automatik-Regel / Autopilot)
+Autopilot {
+    #[command(subcommand)]
+    action: AutopilotCmd,
+},
+```
+
+```rust
+#[derive(Subcommand)]
+enum AutopilotCmd {
+    /// List all automatic rules
+    List,
+    /// Show last-run state of a rule
+    State { name_or_uuid: String },
+}
+```
+
+The `state` handler fetches `changed` via `/jdev/sps/io/<state_uuid>/state`,
+interprets the numeric value as a unix timestamp, and formats it with `chrono`
+(already a dependency).
+
+## Open Questions
+
+1. **State endpoint** — uncertain whether `states.changed` UUID works with
+   `/jdev/sps/io/<uuid>/state` or requires WebSocket. Needs verification against
+   a real Miniserver. Fallback: `/dev/sps/io/<uuid>/all`.
+2. **Structure key** — need to confirm the exact key name (`autopilot` vs
+   `autopilotrules`) against a real `LoxApp3.json`. Won't know until tested.
+3. **History state format** — value format is undocumented. Could be a unix
+   timestamp, a text blob, or structured data. Deferred until confirmed.
+4. **Empty section** — if no autopilot rules have been created, the `autopilot`
+   key may be absent or an empty object. Handle gracefully.
+
+## Out of Scope
+
+- Triggering or activating rules (no API exists)
+- Creating, editing, or deleting rules (app-only)
+- History state display (deferred, format unknown)
+- Cross-referencing which controls were last triggered by an autopilot rule

--- a/src/client.rs
+++ b/src/client.rs
@@ -11,6 +11,16 @@ use std::time::Duration;
 use crate::config::Config;
 use crate::token::TokenStore;
 
+// ── AutopilotRule ─────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub struct AutopilotRule {
+    pub name: String,
+    pub uuid: String,
+    pub state_changed: String,
+    pub state_history: String,
+}
+
 // ── Control ───────────────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone)]
@@ -363,6 +373,64 @@ impl LoxClient {
                 .cmp(&b.0.parse::<i32>().unwrap_or(0))
         });
         Ok(result)
+    }
+
+    pub fn list_autopilot_rules(&mut self) -> Result<Vec<AutopilotRule>> {
+        let structure = self.get_structure()?;
+        let mut rules = Vec::new();
+        if let Some(map) = structure.get("autopilot").and_then(|a| a.as_object()) {
+            for (uuid, entry) in map {
+                let name = entry
+                    .get("name")
+                    .and_then(|n| n.as_str())
+                    .unwrap_or("?")
+                    .to_string();
+                let state_changed = entry
+                    .get("states")
+                    .and_then(|s| s.get("changed"))
+                    .and_then(|c| c.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let state_history = entry
+                    .get("states")
+                    .and_then(|s| s.get("history"))
+                    .and_then(|h| h.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                rules.push(AutopilotRule {
+                    name,
+                    uuid: uuid.clone(),
+                    state_changed,
+                    state_history,
+                });
+            }
+        }
+        rules.sort_by(|a, b| a.name.cmp(&b.name));
+        Ok(rules)
+    }
+
+    pub fn find_autopilot_rule(&mut self, name_or_uuid: &str) -> Result<AutopilotRule> {
+        let rules = self.list_autopilot_rules()?;
+        if is_uuid(name_or_uuid) {
+            return rules
+                .into_iter()
+                .find(|r| r.uuid == name_or_uuid)
+                .context("Autopilot rule UUID not found");
+        }
+        let matches: Vec<AutopilotRule> = rules
+            .into_iter()
+            .filter(|r| r.name.to_lowercase().contains(&name_or_uuid.to_lowercase()))
+            .collect();
+        match matches.len() {
+            0 => bail!("No autopilot rule matching '{}'", name_or_uuid),
+            1 => Ok(matches.into_iter().next().unwrap()),
+            _ => {
+                for r in &matches {
+                    eprintln!("  {}", r.name);
+                }
+                bail!("Ambiguous: '{}'", name_or_uuid)
+            }
+        }
     }
 
     pub fn find_control(&mut self, name_or_uuid: &str) -> Result<Control> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -361,6 +361,11 @@ enum Cmd {
         #[command(subcommand)]
         action: TokenCmd,
     },
+    /// List and inspect automatic rules (Automatik-Regel / Autopilot)
+    Autopilot {
+        #[command(subcommand)]
+        action: AutopilotCmd,
+    },
 }
 
 #[derive(Subcommand)]
@@ -377,6 +382,14 @@ enum TokenCmd {
     Refresh,
     /// Revoke token on the Miniserver
     Revoke,
+}
+
+#[derive(Subcommand)]
+enum AutopilotCmd {
+    /// List all automatic rules
+    List,
+    /// Show when a rule last fired
+    State { name_or_uuid: String },
 }
 
 #[derive(Subcommand)]
@@ -2264,6 +2277,73 @@ fn main() -> Result<()> {
                 }
             }
         },
+        Cmd::Autopilot { action } => {
+            let mut lox = LoxClient::new(Config::load()?);
+            match action {
+                AutopilotCmd::List => {
+                    let rules = lox.list_autopilot_rules()?;
+                    if rules.is_empty() {
+                        println!("No autopilot rules found.");
+                    } else if cli.json {
+                        let arr: Vec<serde_json::Value> = rules
+                            .iter()
+                            .map(|r| {
+                                serde_json::json!({
+                                    "name": r.name,
+                                    "uuid": r.uuid,
+                                    "state_changed": r.state_changed,
+                                    "state_history": r.state_history,
+                                })
+                            })
+                            .collect();
+                        println!("{}", serde_json::to_string_pretty(&arr)?);
+                    } else {
+                        let name_w = rules.iter().map(|r| r.name.len()).max().unwrap_or(4).max(4);
+                        println!("{:<width$}  {}", "NAME", "UUID", width = name_w);
+                        for r in &rules {
+                            println!("{:<width$}  {}", r.name, r.uuid, width = name_w);
+                        }
+                    }
+                }
+                AutopilotCmd::State { name_or_uuid } => {
+                    let rule = lox.find_autopilot_rule(&name_or_uuid)?;
+                    let resp = lox.get_json(&format!("/jdev/sps/io/{}/state", rule.state_changed));
+                    if cli.json {
+                        match resp {
+                            Ok(v) => println!("{}", serde_json::to_string_pretty(&v)?),
+                            Err(e) => bail!("{}", e),
+                        }
+                    } else {
+                        let last_run = match resp {
+                            Ok(v) => {
+                                let raw = v
+                                    .get("LL")
+                                    .and_then(|ll| ll.get("value"))
+                                    .and_then(|val| val.as_str())
+                                    .unwrap_or("");
+                                if raw.is_empty() || raw == "0" {
+                                    "never".to_string()
+                                } else if let Ok(secs) = raw.parse::<i64>() {
+                                    let lox_epoch = chrono::NaiveDate::from_ymd_opt(2009, 1, 1)
+                                        .unwrap()
+                                        .and_hms_opt(0, 0, 0)
+                                        .unwrap()
+                                        .and_local_timezone(chrono::Local)
+                                        .unwrap();
+                                    let dt = lox_epoch + chrono::Duration::seconds(secs);
+                                    dt.format("%Y-%m-%d %H:%M:%S").to_string()
+                                } else {
+                                    raw.to_string()
+                                }
+                            }
+                            Err(_) => "unavailable".to_string(),
+                        };
+                        println!("Rule:     {}", rule.name);
+                        println!("Last run: {}", last_run);
+                    }
+                }
+            }
+        }
         Cmd::Cache { action } => {
             let cfg = Config::load()?;
             let cache = LoxClient::cache_path(&cfg);


### PR DESCRIPTION
## Summary
- `lox autopilot list` — parses `autopilot` section from structure cache (no extra HTTP calls), prints name/UUID table sorted by name; `--json` includes state UUIDs
- `lox autopilot state <name>` — fuzzy-matches rule by name, fetches `states.changed` via state API, formats timestamp using Loxone epoch (2009-01-01); shows "unavailable" gracefully if endpoint returns 404

## Test plan
- [ ] `lox autopilot list` shows rules table
- [ ] `lox autopilot list --json` returns full JSON with state UUIDs
- [ ] `lox autopilot state <name>` resolves by fuzzy name match and shows last run time
- [ ] Graceful output when no rules exist or state endpoint unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)