### PR TITLE
Rename: backup→config, config→setup, restore→upload

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -13,9 +13,9 @@ lox get "Temperatur [OG Schlafzimmer]"
 ## Setup
 
 ```bash
-lox config set --host https://192.168.1.100 --user admin --pass secret
-lox config set --serial YOUR_SERIAL    # enables correct TLS hostname
-lox config show                        # show config (password redacted)
+lox setup set --host https://192.168.1.100 --user admin --pass secret
+lox setup set --serial YOUR_SERIAL     # enables correct TLS hostname
+lox setup show                         # show config (password redacted)
 ```
 
 ### Aliases
@@ -192,16 +192,16 @@ lox autopilot state "Rule Name"        # show when a rule last fired
 
 ---
 
-## Backup (Loxone Config)
+## Loxone Config
 
 ```bash
-lox backup download                    # download latest config ZIP via FTP
-lox backup download --extract          # download + decompress to .Loxone XML
-lox backup download -o config.zip      # custom output filename
-lox backup list                        # list all backups on the Miniserver
-lox backup extract config.zip          # decompress LoxCC → .Loxone XML
-lox backup extract config.zip -o out.Loxone
-lox backup restore config.zip --force  # upload to Miniserver (dangerous)
+lox config download                    # download latest config ZIP via FTP
+lox config download --extract          # download + decompress to .Loxone XML
+lox config download -o config.zip      # custom output filename
+lox config list                        # list all configs on the Miniserver
+lox config extract config.zip          # decompress LoxCC → .Loxone XML
+lox config extract config.zip -o out.Loxone
+lox config upload config.zip --force   # upload to Miniserver (dangerous)
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -85,10 +85,10 @@ cp target/release/lox ~/.local/bin/
 ## Setup
 
 ```bash
-lox config set --host https://192.168.1.100 --user USER --pass PASS
+lox setup set --host https://192.168.1.100 --user USER --pass PASS
 
 # With serial for correct TLS hostname (avoids cert warnings)
-lox config set --host https://192.168.1.100 --user USER --pass PASS --serial YOUR_SERIAL
+lox setup set --host https://192.168.1.100 --user USER --pass PASS --serial YOUR_SERIAL
 ```
 
 Config: `~/.lox/config.yaml`
@@ -126,7 +126,7 @@ lox thermostat "Heizung" --temp 22.5   # Set temperature
 lox alarm "Alarmanlage" arm            # Arm alarm
 lox if "Temperatur" gt 25 && echo hot  # Conditional logic
 lox status --energy                    # Energy dashboard
-lox backup download --extract          # Download & extract Loxone Config
+lox config download --extract          # Download & extract Loxone Config
 lox run abend                          # Run a scene
 lox send <uuid> <command>              # Raw command
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,10 +87,10 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Cmd {
-    /// Configure connection
-    Config {
+    /// Configure connection settings
+    Setup {
         #[command(subcommand)]
-        action: ConfigCmd,
+        action: SetupCmd,
     },
     /// Manage control name aliases
     Alias {
@@ -363,10 +363,10 @@ enum Cmd {
         #[command(subcommand)]
         action: TokenCmd,
     },
-    /// Download and manage Miniserver configuration backups
-    Backup {
+    /// Download, inspect, and manage Loxone Config files
+    Config {
         #[command(subcommand)]
-        action: BackupCmd,
+        action: ConfigCmd,
     },
     /// List and inspect automatic rules (Automatik-Regel / Autopilot)
     Autopilot {
@@ -472,7 +472,7 @@ enum CacheCmd {
 }
 
 #[derive(Subcommand)]
-enum ConfigCmd {
+enum SetupCmd {
     /// Set one or more config fields (omitted fields are preserved)
     Set {
         #[arg(long)]
@@ -510,8 +510,8 @@ enum SceneCmd {
 }
 
 #[derive(Subcommand)]
-enum BackupCmd {
-    /// Download the latest configuration backup from the Miniserver
+enum ConfigCmd {
+    /// Download the latest Loxone Config from the Miniserver via FTP
     Download {
         /// Custom output filename
         #[arg(short, long)]
@@ -520,19 +520,19 @@ enum BackupCmd {
         #[arg(long)]
         extract: bool,
     },
-    /// List available backups on the Miniserver
+    /// List available configs on the Miniserver
     List,
-    /// Decompress a local backup ZIP to XML
+    /// Decompress a local config ZIP to .Loxone XML
     Extract {
-        /// Path to a backup ZIP file
+        /// Path to a config ZIP file
         file: String,
         /// Custom output filename
         #[arg(short, long)]
         output: Option<String>,
     },
-    /// Upload a backup to the Miniserver (dangerous — requires --force)
-    Restore {
-        /// Path to a backup ZIP file
+    /// Upload a config to the Miniserver via FTP (dangerous — requires --force)
+    Upload {
+        /// Path to a config ZIP file
         file: String,
         /// Confirm the upload
         #[arg(long)]
@@ -546,8 +546,8 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
 
     match cli.cmd {
-        Cmd::Config { action } => match action {
-            ConfigCmd::Set {
+        Cmd::Setup { action } => match action {
+            SetupCmd::Set {
                 host,
                 user,
                 pass,
@@ -572,7 +572,7 @@ fn main() -> Result<()> {
                 }
                 cfg.save()?;
             }
-            ConfigCmd::Show => {
+            SetupCmd::Show => {
                 let cfg = Config::load()?;
                 println!("host:   {}", cfg.host);
                 println!("user:   {}", cfg.user);
@@ -2468,13 +2468,13 @@ fn main() -> Result<()> {
                 }
             }
         }
-        Cmd::Backup { action } => {
+        Cmd::Config { action } => {
             let cfg = Config::load()?;
             match action {
-                BackupCmd::List => {
+                ConfigCmd::List => {
                     let backups = ftp::list_backups(&cfg)?;
                     if backups.is_empty() {
-                        println!("No configuration backups found on the Miniserver.");
+                        println!("No configs found on the Miniserver.");
                     } else if cli.json {
                         let arr: Vec<serde_json::Value> = backups
                             .iter()
@@ -2502,10 +2502,10 @@ fn main() -> Result<()> {
                         }
                     }
                 }
-                BackupCmd::Download { output, extract } => {
+                ConfigCmd::Download { output, extract } => {
                     let backups = ftp::list_backups(&cfg)?;
                     if backups.is_empty() {
-                        bail!("No configuration backups found on the Miniserver.");
+                        bail!("No configs found on the Miniserver.");
                     }
                     let newest = &backups[0];
                     eprintln!(
@@ -2535,7 +2535,7 @@ fn main() -> Result<()> {
                         );
                     }
                 }
-                BackupCmd::Extract { file, output } => {
+                ConfigCmd::Extract { file, output } => {
                     let zip_data =
                         fs::read(&file).with_context(|| format!("Cannot read {}", file))?;
                     eprintln!("Extracting sps0.LoxCC...");
@@ -2551,14 +2551,14 @@ fn main() -> Result<()> {
                         xml_path
                     );
                 }
-                BackupCmd::Restore { file, force } => {
+                ConfigCmd::Upload { file, force } => {
                     if !force {
                         eprintln!(
-                            "⚠  WARNING: Uploading a configuration backup will replace the current\n\
-                             \x20  Miniserver programming. A bad configuration can require physical\n\
-                             \x20  SD card access to recover.\n\
+                            "⚠  WARNING: Uploading a config will replace the current Miniserver\n\
+                             \x20  programming. A bad configuration can require physical SD card\n\
+                             \x20  access to recover.\n\
                              \n\
-                             \x20  Backup file: {}\n\
+                             \x20  Config file: {}\n\
                              \n\
                              \x20  Use --force to proceed.",
                             file


### PR DESCRIPTION
## Summary

- `lox backup` → `lox config` — aligns with "Loxone Config" product name
- `lox config` (CLI settings) → `lox setup`
- `backup restore` → `config upload` — describes FTP action without implying activation
- README.md and COMMANDS.md updated

```
lox setup set --host ... --user ... --pass ...
lox setup show

lox config download [--extract]
lox config list
lox config extract <file.zip>
lox config upload <file.zip> --force
```

## Test plan

- [x] 53/53 tests pass
- [x] `cargo clippy` clean
- [x] `lox --help`, `lox config --help`, `lox setup --help` verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)