### PR TITLE
Fix Homebrew install by adding explicit tap URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ An agent can discover your home (`lox ls --json`), read sensor values, control d
 
 **Homebrew (macOS/Linux):**
 ```bash
+brew tap discostu105/lox https://github.com/discostu105/lox
 brew install discostu105/lox/lox
 ```
 


### PR DESCRIPTION
## Summary
- The Homebrew formula lives in this repo at `Formula/lox.rb`, not in a separate `homebrew-lox` repository
- `brew install discostu105/lox/lox` without an explicit tap tries to clone `github.com/discostu105/homebrew-lox`, which doesn't exist
- Added a `brew tap` step with an explicit URL pointing to this repo so Homebrew finds the formula correctly

Fixes #31

## Test plan
- [ ] Run `brew tap discostu105/lox https://github.com/discostu105/lox` and verify it clones successfully without auth prompts
- [ ] Run `brew install discostu105/lox/lox` and verify `lox --version` works

https://claude.ai/code/session_018WAJLc9jtETBJGGQsnYx7X