### PR TITLE
WebSocket real-time state streaming (lox stream)

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -287,6 +287,19 @@ lox watch "Temperatur" -i 5            # custom poll interval in seconds
 
 ---
 
+## Streaming
+
+```bash
+lox stream                             # stream all state changes via WebSocket (NDJSON with --json)
+lox stream --room "Kitchen"            # filter by room
+lox stream --type LightControllerV2    # filter by control type
+lox stream --control "Kitchen Light"   # filter by control name
+lox stream --initial                   # include initial state snapshot
+lox stream --json                      # output as NDJSON (one JSON object per line)
+```
+
+---
+
 ## Firmware Update
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ lox blind "Beschattung Süd" pos 50     # Blind to 50%
 lox light mood "Licht" plus            # Next light mood
 lox thermostat "Heizung" temp 22.5     # Set temperature
 lox alarm "Alarmanlage" arm            # Arm alarm
+lox stream --room "Kitchen" --json     # Real-time WebSocket state stream
 lox if "Temperatur" gt 25 && echo hot  # Conditional logic
 lox status --energy                    # Energy dashboard
 lox config download --extract          # Download & extract Loxone Config

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod ftp;
 mod loxcc;
 mod loxone_xml;
 mod scene;
+mod stream;
 mod token;
 mod ws;
 
@@ -111,7 +112,8 @@ Control:
   run, send                    Run scenes, send raw commands
 
 Inspect:
-  ls, get, info, watch, if     List, query, monitor controls
+  ls, get, info, watch, stream  List, query, monitor, stream controls
+  if                            Conditional state check
   rooms, categories, modes     Structure metadata
   globals, sensors, energy     Global states, sensor & energy readings
   weather, stats, history      Weather, statistics
@@ -370,6 +372,21 @@ enum Cmd {
             help = "Poll interval in seconds"
         )]
         interval: u64,
+    },
+    /// Stream real-time state changes via WebSocket (Ctrl+C to stop)
+    Stream {
+        /// Filter by control type
+        #[arg(long, short = 't')]
+        r#type: Option<String>,
+        /// Filter by room
+        #[arg(long, short = 'r')]
+        room: Option<String>,
+        /// Filter by control name (fuzzy match)
+        #[arg(long, short = 'c')]
+        control: Option<String>,
+        /// Include initial state snapshot
+        #[arg(long)]
+        initial: bool,
     },
     /// Check state (exit 0=match, 1=no match)
     If {
@@ -2660,6 +2677,95 @@ fn main() -> Result<()> {
             }
         }
 
+        Cmd::Stream {
+            r#type,
+            room,
+            control,
+            initial,
+        } => {
+            let cfg = Config::load()?;
+            let mut lox = LoxClient::new(cfg.clone());
+            let structure = lox.get_structure()?.clone();
+            let state_map = stream::build_state_uuid_map(&structure);
+            let json = cli.json;
+
+            if !quiet {
+                eprintln!("Streaming state changes (Ctrl+C to stop)...");
+            }
+
+            let type_filter = r#type;
+            let room_filter = room;
+            let control_filter = control;
+            let mut initial_done = false;
+
+            let rt = tokio::runtime::Runtime::new()?;
+            rt.block_on(stream::stream_events(&cfg, |events| {
+                for event in &events {
+                    match event {
+                        stream::StateEvent::ValueState { uuid, value } => {
+                            if !initial && !initial_done {
+                                continue;
+                            }
+                            if let Some(info) = state_map.get(uuid) {
+                                if !matches_filters(
+                                    info,
+                                    type_filter.as_deref(),
+                                    room_filter.as_deref(),
+                                    control_filter.as_deref(),
+                                ) {
+                                    continue;
+                                }
+                                print_stream_event(
+                                    json,
+                                    &info.control_name,
+                                    &info.state_name,
+                                    &format!("{}", value),
+                                    info.room.as_deref(),
+                                    &info.control_type,
+                                    uuid,
+                                );
+                            }
+                        }
+                        stream::StateEvent::TextState { uuid, text, .. } => {
+                            if !initial && !initial_done {
+                                continue;
+                            }
+                            if let Some(info) = state_map.get(uuid) {
+                                if !matches_filters(
+                                    info,
+                                    type_filter.as_deref(),
+                                    room_filter.as_deref(),
+                                    control_filter.as_deref(),
+                                ) {
+                                    continue;
+                                }
+                                print_stream_event(
+                                    json,
+                                    &info.control_name,
+                                    &info.state_name,
+                                    text,
+                                    info.room.as_deref(),
+                                    &info.control_type,
+                                    uuid,
+                                );
+                            }
+                        }
+                        stream::StateEvent::OutOfService => {
+                            if !quiet {
+                                eprintln!("Miniserver going offline (firmware update?). Exiting.");
+                            }
+                            std::process::exit(0);
+                        }
+                        _ => {} // Keepalive, Daytimer, Weather — skip for now
+                    }
+                }
+                if !initial_done {
+                    initial_done = true;
+                }
+                Ok(())
+            }))?;
+        }
+
         Cmd::If {
             name_or_uuid,
             op,
@@ -3518,6 +3624,80 @@ fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+// ── Stream helpers ────────────────────────────────────────────────────────────
+
+fn matches_filters(
+    info: &stream::StateUuidInfo,
+    type_filter: Option<&str>,
+    room_filter: Option<&str>,
+    control_filter: Option<&str>,
+) -> bool {
+    if let Some(tf) = type_filter {
+        if !info
+            .control_type
+            .to_lowercase()
+            .contains(&tf.to_lowercase())
+        {
+            return false;
+        }
+    }
+    if let Some(rf) = room_filter {
+        if !info
+            .room
+            .as_deref()
+            .unwrap_or("")
+            .to_lowercase()
+            .contains(&rf.to_lowercase())
+        {
+            return false;
+        }
+    }
+    if let Some(cf) = control_filter {
+        if !info
+            .control_name
+            .to_lowercase()
+            .contains(&cf.to_lowercase())
+        {
+            return false;
+        }
+    }
+    true
+}
+
+fn print_stream_event(
+    json: bool,
+    control: &str,
+    state: &str,
+    value: &str,
+    room: Option<&str>,
+    control_type: &str,
+    uuid: &str,
+) {
+    if json {
+        println!(
+            "{}",
+            serde_json::json!({
+                "timestamp": chrono::Local::now().to_rfc3339(),
+                "control": control,
+                "state": state,
+                "value": value,
+                "room": room,
+                "type": control_type,
+                "uuid": uuid,
+            })
+        );
+    } else {
+        println!(
+            "[{}]  {} ({}) = {}  [{}]",
+            now_hms(),
+            control,
+            state,
+            value,
+            room.unwrap_or("-"),
+        );
+    }
 }
 
 fn rgb_to_hsv(r: u8, g: u8, b: u8) -> (u16, u16, u16) {

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,0 +1,837 @@
+//! Loxone WebSocket binary protocol parser and real-time state streaming.
+//!
+//! Connects to the Miniserver via WebSocket, subscribes to binary status updates,
+//! and yields structured state-change events. Used by `lox stream` and `lox otel`.
+
+use anyhow::{bail, Result};
+use futures_util::{SinkExt, StreamExt};
+use serde_json::Value;
+use std::collections::HashMap;
+use tokio_tungstenite::tungstenite::Message;
+
+use crate::config::Config;
+use crate::ws::LoxWsClient;
+
+// ── Binary message types ────────────────────────────────────────────────────
+
+const MSG_TEXT: u8 = 0x00;
+const MSG_BINARY_FILE: u8 = 0x01;
+const MSG_VALUE_STATES: u8 = 0x02;
+const MSG_TEXT_STATES: u8 = 0x03;
+const MSG_DAYTIMER_STATES: u8 = 0x04;
+const MSG_OUT_OF_SERVICE: u8 = 0x05;
+const MSG_KEEPALIVE: u8 = 0x06;
+const MSG_WEATHER_STATES: u8 = 0x07;
+
+// ── State events ────────────────────────────────────────────────────────────
+
+/// A single state-change event from the Miniserver WebSocket stream.
+#[derive(Debug, Clone)]
+#[allow(dead_code)] // Fields used by otel exporter
+pub enum StateEvent {
+    /// Numeric state update: UUID → f64 value
+    ValueState { uuid: String, value: f64 },
+    /// Text state update: UUID → string value
+    TextState {
+        uuid: String,
+        icon_uuid: String,
+        text: String,
+    },
+    /// Daytimer schedule entry
+    DaytimerState {
+        uuid: String,
+        default_value: f64,
+        entries: Vec<DaytimerEntry>,
+    },
+    /// Weather forecast data
+    WeatherState {
+        uuid: String,
+        last_update: u32,
+        entries: Vec<WeatherEntry>,
+    },
+    /// Keepalive heartbeat
+    Keepalive,
+    /// Miniserver going offline (firmware update, etc.)
+    OutOfService,
+}
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)] // Fields used by otel exporter
+pub struct DaytimerEntry {
+    pub mode: i32,
+    pub from: i32,
+    pub to: i32,
+    pub need_activate: i32,
+    pub value: f64,
+}
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)] // Fields used by otel exporter
+pub struct WeatherEntry {
+    pub timestamp: i32,
+    pub weather_type: i32,
+    pub wind_direction: i32,
+    pub solar_radiation: i32,
+    pub relative_humidity: i32,
+    pub temperature: f64,
+    pub perceived_temperature: f64,
+    pub dew_point: f64,
+    pub precipitation: f64,
+    pub wind_speed: f64,
+    pub barometric_pressure: f64,
+}
+
+// ── State UUID mapping ──────────────────────────────────────────────────────
+
+/// Metadata for a state UUID, linking it back to its parent control.
+#[derive(Debug, Clone)]
+#[allow(dead_code)] // Fields used by otel exporter
+pub struct StateUuidInfo {
+    pub control_name: String,
+    pub control_uuid: String,
+    pub state_name: String,
+    pub control_type: String,
+    pub room: Option<String>,
+    pub category: Option<String>,
+}
+
+/// Build a map from state UUID → control metadata by walking the structure cache.
+///
+/// Each control in `LoxApp3.json` has a `states` object like:
+/// ```json
+/// { "active": "state-uuid-1", "value": "state-uuid-2" }
+/// ```
+/// This function creates a reverse map so we can look up which control owns a state UUID.
+pub fn build_state_uuid_map(structure: &Value) -> HashMap<String, StateUuidInfo> {
+    let mut map = HashMap::new();
+
+    // Build room/category name lookups
+    let rooms = build_name_map(structure, "rooms");
+    let cats = build_name_map(structure, "cats");
+
+    // Walk controls and their states
+    if let Some(ctrl_map) = structure.get("controls").and_then(|c| c.as_object()) {
+        for (ctrl_uuid, ctrl) in ctrl_map {
+            let name = str_field(ctrl, "name");
+            let typ = str_field(ctrl, "type");
+            let room = ctrl
+                .get("room")
+                .and_then(|r| r.as_str())
+                .and_then(|r| rooms.get(r))
+                .cloned();
+            let cat = ctrl
+                .get("cat")
+                .and_then(|c| c.as_str())
+                .and_then(|c| cats.get(c))
+                .cloned();
+
+            // Control's own states
+            add_states_from(
+                &mut map,
+                ctrl,
+                ctrl_uuid,
+                &name,
+                &typ,
+                room.as_deref(),
+                cat.as_deref(),
+            );
+
+            // Sub-control states
+            if let Some(subs) = ctrl.get("subControls").and_then(|s| s.as_object()) {
+                for (sub_uuid, sub) in subs {
+                    let sub_name = format!("{}/{}", name, str_field(sub, "name"));
+                    let sub_type = str_field(sub, "type");
+                    add_states_from(
+                        &mut map,
+                        sub,
+                        sub_uuid,
+                        &sub_name,
+                        &sub_type,
+                        room.as_deref(),
+                        cat.as_deref(),
+                    );
+                }
+            }
+        }
+    }
+
+    // Global states (operatingMode, sunrise, etc.)
+    if let Some(globals) = structure.get("globalStates").and_then(|g| g.as_object()) {
+        for (state_name, uuid_val) in globals {
+            if let Some(uuid) = uuid_val.as_str() {
+                map.insert(
+                    uuid.to_string(),
+                    StateUuidInfo {
+                        control_name: "Global".to_string(),
+                        control_uuid: String::new(),
+                        state_name: state_name.clone(),
+                        control_type: "GlobalState".to_string(),
+                        room: None,
+                        category: None,
+                    },
+                );
+            }
+        }
+    }
+
+    // Autopilot rule states
+    if let Some(auto_map) = structure.get("autopilot").and_then(|a| a.as_object()) {
+        for (rule_uuid, rule) in auto_map {
+            let rule_name = str_field(rule, "name");
+            if let Some(states) = rule.get("states").and_then(|s| s.as_object()) {
+                for (state_name, uuid_val) in states {
+                    if let Some(uuid) = uuid_val.as_str() {
+                        map.insert(
+                            uuid.to_string(),
+                            StateUuidInfo {
+                                control_name: rule_name.clone(),
+                                control_uuid: rule_uuid.clone(),
+                                state_name: state_name.clone(),
+                                control_type: "AutopilotRule".to_string(),
+                                room: None,
+                                category: None,
+                            },
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    map
+}
+
+fn add_states_from(
+    map: &mut HashMap<String, StateUuidInfo>,
+    ctrl: &Value,
+    ctrl_uuid: &str,
+    name: &str,
+    typ: &str,
+    room: Option<&str>,
+    cat: Option<&str>,
+) {
+    if let Some(states) = ctrl.get("states").and_then(|s| s.as_object()) {
+        for (state_name, uuid_val) in states {
+            if let Some(uuid) = uuid_val.as_str() {
+                map.insert(
+                    uuid.to_string(),
+                    StateUuidInfo {
+                        control_name: name.to_string(),
+                        control_uuid: ctrl_uuid.to_string(),
+                        state_name: state_name.clone(),
+                        control_type: typ.to_string(),
+                        room: room.map(|r| r.to_string()),
+                        category: cat.map(|c| c.to_string()),
+                    },
+                );
+            }
+        }
+    }
+}
+
+fn build_name_map(structure: &Value, key: &str) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+    if let Some(obj) = structure.get(key).and_then(|v| v.as_object()) {
+        for (uuid, entry) in obj {
+            if let Some(name) = entry.get("name").and_then(|n| n.as_str()) {
+                map.insert(uuid.clone(), name.to_string());
+            }
+        }
+    }
+    map
+}
+
+fn str_field(val: &Value, key: &str) -> String {
+    val.get(key)
+        .and_then(|v| v.as_str())
+        .unwrap_or("?")
+        .to_string()
+}
+
+// ── Binary protocol parsing ─────────────────────────────────────────────────
+
+/// Loxone binary message header (8 bytes).
+#[derive(Debug)]
+struct BinHeader {
+    msg_type: u8,
+    #[allow(dead_code)]
+    estimated: bool,
+    payload_len: u32,
+}
+
+fn parse_header(data: &[u8]) -> Result<BinHeader> {
+    if data.len() < 8 {
+        bail!("Binary header too short: {} bytes", data.len());
+    }
+    if data[0] != 0x03 {
+        bail!("Invalid binary header magic: 0x{:02x}", data[0]);
+    }
+    let msg_type = data[1];
+    let estimated = data[2] & 0x01 != 0;
+    let payload_len = u32::from_le_bytes([data[4], data[5], data[6], data[7]]);
+    Ok(BinHeader {
+        msg_type,
+        estimated,
+        payload_len,
+    })
+}
+
+/// Parse a 16-byte Loxone UUID from binary format.
+///
+/// Format: `{u32_le}-{u16_le}-{u16_le}-{8×u8_hex}`
+pub fn parse_uuid(data: &[u8]) -> Result<String> {
+    if data.len() < 16 {
+        bail!("UUID too short: {} bytes", data.len());
+    }
+    let d1 = u32::from_le_bytes([data[0], data[1], data[2], data[3]]);
+    let d2 = u16::from_le_bytes([data[4], data[5]]);
+    let d3 = u16::from_le_bytes([data[6], data[7]]);
+    Ok(format!(
+        "{:08x}-{:04x}-{:04x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
+        d1, d2, d3, data[8], data[9], data[10], data[11], data[12], data[13], data[14], data[15],
+    ))
+}
+
+/// Parse Value-State event table: repeated 24-byte records (UUID + f64).
+fn parse_value_states(data: &[u8]) -> Result<Vec<StateEvent>> {
+    let mut events = Vec::new();
+    let mut offset = 0;
+    while offset + 24 <= data.len() {
+        let uuid = parse_uuid(&data[offset..offset + 16])?;
+        let value = f64::from_le_bytes([
+            data[offset + 16],
+            data[offset + 17],
+            data[offset + 18],
+            data[offset + 19],
+            data[offset + 20],
+            data[offset + 21],
+            data[offset + 22],
+            data[offset + 23],
+        ]);
+        events.push(StateEvent::ValueState { uuid, value });
+        offset += 24;
+    }
+    Ok(events)
+}
+
+/// Parse Text-State event table: variable-length records.
+fn parse_text_states(data: &[u8]) -> Result<Vec<StateEvent>> {
+    let mut events = Vec::new();
+    let mut offset = 0;
+    while offset + 36 <= data.len() {
+        // 16 bytes UUID + 16 bytes icon UUID + 4 bytes text length
+        let uuid = parse_uuid(&data[offset..offset + 16])?;
+        let icon_uuid = parse_uuid(&data[offset + 16..offset + 32])?;
+        let text_len = u32::from_le_bytes([
+            data[offset + 32],
+            data[offset + 33],
+            data[offset + 34],
+            data[offset + 35],
+        ]) as usize;
+        offset += 36;
+        if offset + text_len > data.len() {
+            break;
+        }
+        let text = String::from_utf8_lossy(&data[offset..offset + text_len]).to_string();
+        // Round up to next multiple of 4
+        let padded_len = (text_len + 3) & !3;
+        offset += padded_len;
+        events.push(StateEvent::TextState {
+            uuid,
+            icon_uuid,
+            text,
+        });
+    }
+    Ok(events)
+}
+
+/// Parse Daytimer-State event table.
+fn parse_daytimer_states(data: &[u8]) -> Result<Vec<StateEvent>> {
+    let mut events = Vec::new();
+    let mut offset = 0;
+    while offset + 28 <= data.len() {
+        let uuid = parse_uuid(&data[offset..offset + 16])?;
+        let default_value =
+            f64::from_le_bytes(data[offset + 16..offset + 24].try_into().unwrap_or([0; 8]));
+        let nr_entries =
+            i32::from_le_bytes(data[offset + 24..offset + 28].try_into().unwrap_or([0; 4]))
+                as usize;
+        offset += 28;
+        let mut entries = Vec::new();
+        for _ in 0..nr_entries {
+            if offset + 24 > data.len() {
+                break;
+            }
+            let mode = i32::from_le_bytes(data[offset..offset + 4].try_into().unwrap_or([0; 4]));
+            let from =
+                i32::from_le_bytes(data[offset + 4..offset + 8].try_into().unwrap_or([0; 4]));
+            let to = i32::from_le_bytes(data[offset + 8..offset + 12].try_into().unwrap_or([0; 4]));
+            let need_activate =
+                i32::from_le_bytes(data[offset + 12..offset + 16].try_into().unwrap_or([0; 4]));
+            let value =
+                f64::from_le_bytes(data[offset + 16..offset + 24].try_into().unwrap_or([0; 8]));
+            entries.push(DaytimerEntry {
+                mode,
+                from,
+                to,
+                need_activate,
+                value,
+            });
+            offset += 24;
+        }
+        events.push(StateEvent::DaytimerState {
+            uuid,
+            default_value,
+            entries,
+        });
+    }
+    Ok(events)
+}
+
+/// Parse Weather-State event table.
+fn parse_weather_states(data: &[u8]) -> Result<Vec<StateEvent>> {
+    let mut events = Vec::new();
+    let mut offset = 0;
+    while offset + 24 <= data.len() {
+        let uuid = parse_uuid(&data[offset..offset + 16])?;
+        let last_update =
+            u32::from_le_bytes(data[offset + 16..offset + 20].try_into().unwrap_or([0; 4]));
+        let nr_entries =
+            i32::from_le_bytes(data[offset + 20..offset + 24].try_into().unwrap_or([0; 4]))
+                as usize;
+        offset += 24;
+        let mut entries = Vec::new();
+        // Each weather entry: 4×i32 + 7×f64 = 16 + 56 = 72 bytes
+        // But official spec: 4×i32 (16 bytes) + 6×f64 (48 bytes) = 68 bytes? Let's check:
+        // timestamp(i32) + weatherType(i32) + windDirection(i32) + solarRadiation(i32)
+        // + relativeHumidity(i32) = 5×i32 = 20 bytes
+        // + temperature(f64) + perceivedTemp(f64) + dewPoint(f64) + precipitation(f64)
+        //   + windSpeed(f64) + barometricPressure(f64) = 6×f64 = 48 bytes
+        // Total = 68 bytes per entry
+        for _ in 0..nr_entries {
+            if offset + 68 > data.len() {
+                break;
+            }
+            let timestamp =
+                i32::from_le_bytes(data[offset..offset + 4].try_into().unwrap_or([0; 4]));
+            let weather_type =
+                i32::from_le_bytes(data[offset + 4..offset + 8].try_into().unwrap_or([0; 4]));
+            let wind_direction =
+                i32::from_le_bytes(data[offset + 8..offset + 12].try_into().unwrap_or([0; 4]));
+            let solar_radiation =
+                i32::from_le_bytes(data[offset + 12..offset + 16].try_into().unwrap_or([0; 4]));
+            let relative_humidity =
+                i32::from_le_bytes(data[offset + 16..offset + 20].try_into().unwrap_or([0; 4]));
+            let temperature =
+                f64::from_le_bytes(data[offset + 20..offset + 28].try_into().unwrap_or([0; 8]));
+            let perceived_temperature =
+                f64::from_le_bytes(data[offset + 28..offset + 36].try_into().unwrap_or([0; 8]));
+            let dew_point =
+                f64::from_le_bytes(data[offset + 36..offset + 44].try_into().unwrap_or([0; 8]));
+            let precipitation =
+                f64::from_le_bytes(data[offset + 44..offset + 52].try_into().unwrap_or([0; 8]));
+            let wind_speed =
+                f64::from_le_bytes(data[offset + 52..offset + 60].try_into().unwrap_or([0; 8]));
+            let barometric_pressure =
+                f64::from_le_bytes(data[offset + 60..offset + 68].try_into().unwrap_or([0; 8]));
+            entries.push(WeatherEntry {
+                timestamp,
+                weather_type,
+                wind_direction,
+                solar_radiation,
+                relative_humidity,
+                temperature,
+                perceived_temperature,
+                dew_point,
+                precipitation,
+                wind_speed,
+                barometric_pressure,
+            });
+            offset += 68;
+        }
+        events.push(StateEvent::WeatherState {
+            uuid,
+            last_update,
+            entries,
+        });
+    }
+    Ok(events)
+}
+
+/// Parse any binary message payload based on the header message type.
+pub fn parse_binary_payload(msg_type: u8, data: &[u8]) -> Result<Vec<StateEvent>> {
+    match msg_type {
+        MSG_VALUE_STATES => parse_value_states(data),
+        MSG_TEXT_STATES => parse_text_states(data),
+        MSG_DAYTIMER_STATES => parse_daytimer_states(data),
+        MSG_WEATHER_STATES => parse_weather_states(data),
+        MSG_KEEPALIVE => Ok(vec![StateEvent::Keepalive]),
+        MSG_OUT_OF_SERVICE => Ok(vec![StateEvent::OutOfService]),
+        MSG_TEXT | MSG_BINARY_FILE => Ok(vec![]), // text responses / binary files — skip
+        other => {
+            eprintln!("Unknown binary message type: 0x{:02x}", other);
+            Ok(vec![])
+        }
+    }
+}
+
+// ── WebSocket streaming ─────────────────────────────────────────────────────
+
+/// Connect to the Miniserver WebSocket, subscribe to state updates,
+/// and call `handler` for each batch of state events.
+///
+/// This function runs until the connection is closed or an error occurs.
+pub async fn stream_events<F>(cfg: &Config, mut handler: F) -> Result<()>
+where
+    F: FnMut(Vec<StateEvent>) -> Result<()>,
+{
+    let ws_client = LoxWsClient::new(cfg.clone());
+    let (mut ws_stream, _resp) = ws_client.connect_raw().await?;
+
+    // Subscribe to binary status updates
+    ws_stream
+        .send(Message::Text("jdev/sps/enablebinstatusupdate".to_string()))
+        .await?;
+
+    // The Loxone protocol sends messages in pairs:
+    // 1. A binary header (8 bytes) telling us the type and size of the next payload
+    // 2. The payload (binary or text)
+    let mut pending_header: Option<BinHeader> = None;
+
+    while let Some(msg) = ws_stream.next().await {
+        let msg = msg?;
+        match msg {
+            Message::Binary(data) => {
+                if let Some(header) = pending_header.take() {
+                    // This is the payload for the previous header
+                    let events = parse_binary_payload(header.msg_type, &data)?;
+                    if !events.is_empty() {
+                        handler(events)?;
+                    }
+                } else if data.len() >= 8 && data[0] == 0x03 {
+                    // This is a binary header
+                    let header = parse_header(&data)?;
+                    if header.estimated {
+                        // Estimated header — wait for the exact header that follows
+                        continue;
+                    }
+                    if header.payload_len == 0 {
+                        // No payload — handle inline (keepalive, out-of-service)
+                        let events = parse_binary_payload(header.msg_type, &[])?;
+                        if !events.is_empty() {
+                            handler(events)?;
+                        }
+                    } else {
+                        pending_header = Some(header);
+                    }
+                }
+            }
+            Message::Text(_) => {
+                // Text responses (command ACKs, etc.) — skip for streaming
+                // Clear pending header if any, since text messages aren't payloads
+                // for binary headers
+            }
+            Message::Ping(data) => {
+                ws_stream.send(Message::Pong(data)).await?;
+            }
+            Message::Close(_) => {
+                break;
+            }
+            _ => {}
+        }
+    }
+
+    Ok(())
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_uuid() {
+        // Example: 0f8e1234-036e-e9ad-ffff-ed57184a04d2
+        // But Loxone format is: {u32_le}-{u16_le}-{u16_le}-{8×u8}
+        //
+        // For u32_le 0x0f8e1234 stored as bytes [0x34, 0x12, 0x8e, 0x0f]
+        // For u16_le 0x036e stored as [0x6e, 0x03]
+        // For u16_le 0xe9ad stored as [0xad, 0xe9]
+        // Last 8 bytes are raw: [0xff, 0xff, 0xed, 0x57, 0x18, 0x4a, 0x04, 0xd2]
+        let data: [u8; 16] = [
+            0x34, 0x12, 0x8e, 0x0f, // u32_le → 0x0f8e1234
+            0x6e, 0x03, // u16_le → 0x036e
+            0xad, 0xe9, // u16_le → 0xe9ad
+            0xff, 0xff, 0xed, 0x57, 0x18, 0x4a, 0x04, 0xd2, // raw bytes
+        ];
+        let uuid = parse_uuid(&data).unwrap();
+        assert_eq!(uuid, "0f8e1234-036e-e9ad-ffffed57184a04d2");
+    }
+
+    #[test]
+    fn test_parse_uuid_too_short() {
+        assert!(parse_uuid(&[0u8; 15]).is_err());
+    }
+
+    #[test]
+    fn test_parse_value_states() {
+        // 2 entries: UUID + f64
+        let mut data = Vec::new();
+        // Entry 1: all zeros UUID, value = 42.0
+        data.extend_from_slice(&[0u8; 16]); // UUID
+        data.extend_from_slice(&42.0f64.to_le_bytes());
+        // Entry 2: all ones UUID, value = -1.5
+        data.extend_from_slice(&[0x01u8; 16]); // UUID
+        data.extend_from_slice(&(-1.5f64).to_le_bytes());
+
+        let events = parse_value_states(&data).unwrap();
+        assert_eq!(events.len(), 2);
+        match &events[0] {
+            StateEvent::ValueState { value, .. } => assert_eq!(*value, 42.0),
+            _ => panic!("Expected ValueState"),
+        }
+        match &events[1] {
+            StateEvent::ValueState { value, .. } => assert_eq!(*value, -1.5),
+            _ => panic!("Expected ValueState"),
+        }
+    }
+
+    #[test]
+    fn test_parse_value_states_truncated() {
+        // 23 bytes — not enough for a full 24-byte entry
+        let data = [0u8; 23];
+        let events = parse_value_states(&data).unwrap();
+        assert_eq!(events.len(), 0);
+    }
+
+    #[test]
+    fn test_parse_text_states() {
+        let mut data = Vec::new();
+        // UUID (16 bytes)
+        data.extend_from_slice(&[0xAAu8; 16]);
+        // Icon UUID (16 bytes)
+        data.extend_from_slice(&[0xBBu8; 16]);
+        // Text length: 5
+        data.extend_from_slice(&5u32.to_le_bytes());
+        // Text: "Hello" (5 bytes) + 3 padding bytes to next multiple of 4
+        data.extend_from_slice(b"Hello\x00\x00\x00");
+
+        let events = parse_text_states(&data).unwrap();
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            StateEvent::TextState { text, .. } => assert_eq!(text, "Hello"),
+            _ => panic!("Expected TextState"),
+        }
+    }
+
+    #[test]
+    fn test_parse_text_states_exact_alignment() {
+        let mut data = Vec::new();
+        data.extend_from_slice(&[0u8; 16]); // UUID
+        data.extend_from_slice(&[0u8; 16]); // Icon UUID
+        data.extend_from_slice(&4u32.to_le_bytes()); // text length = 4 (already aligned)
+        data.extend_from_slice(b"test");
+
+        let events = parse_text_states(&data).unwrap();
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            StateEvent::TextState { text, .. } => assert_eq!(text, "test"),
+            _ => panic!("Expected TextState"),
+        }
+    }
+
+    #[test]
+    fn test_parse_header() {
+        let data: [u8; 8] = [0x03, 0x02, 0x00, 0x00, 0x30, 0x00, 0x00, 0x00];
+        let header = parse_header(&data).unwrap();
+        assert_eq!(header.msg_type, MSG_VALUE_STATES);
+        assert!(!header.estimated);
+        assert_eq!(header.payload_len, 48); // 0x30 = 48 = 2 value-state entries
+    }
+
+    #[test]
+    fn test_parse_header_estimated() {
+        let data: [u8; 8] = [0x03, 0x02, 0x01, 0x00, 0xFF, 0x00, 0x00, 0x00];
+        let header = parse_header(&data).unwrap();
+        assert!(header.estimated);
+    }
+
+    #[test]
+    fn test_parse_header_invalid_magic() {
+        let data: [u8; 8] = [0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+        assert!(parse_header(&data).is_err());
+    }
+
+    #[test]
+    fn test_parse_daytimer_states() {
+        let mut data = Vec::new();
+        // UUID (16 bytes)
+        data.extend_from_slice(&[0x11u8; 16]);
+        // default_value: 22.0
+        data.extend_from_slice(&22.0f64.to_le_bytes());
+        // nrEntries: 1
+        data.extend_from_slice(&1i32.to_le_bytes());
+        // Entry: mode=1, from=480, to=1320, needActivate=0, value=23.5
+        data.extend_from_slice(&1i32.to_le_bytes());
+        data.extend_from_slice(&480i32.to_le_bytes());
+        data.extend_from_slice(&1320i32.to_le_bytes());
+        data.extend_from_slice(&0i32.to_le_bytes());
+        data.extend_from_slice(&23.5f64.to_le_bytes());
+
+        let events = parse_daytimer_states(&data).unwrap();
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            StateEvent::DaytimerState {
+                default_value,
+                entries,
+                ..
+            } => {
+                assert_eq!(*default_value, 22.0);
+                assert_eq!(entries.len(), 1);
+                assert_eq!(entries[0].mode, 1);
+                assert_eq!(entries[0].from, 480);
+                assert_eq!(entries[0].to, 1320);
+                assert_eq!(entries[0].value, 23.5);
+            }
+            _ => panic!("Expected DaytimerState"),
+        }
+    }
+
+    #[test]
+    fn test_parse_weather_states() {
+        let mut data = Vec::new();
+        // UUID (16 bytes)
+        data.extend_from_slice(&[0x22u8; 16]);
+        // lastUpdate: 1000
+        data.extend_from_slice(&1000u32.to_le_bytes());
+        // nrEntries: 1
+        data.extend_from_slice(&1i32.to_le_bytes());
+        // Entry: timestamp=500, weatherType=2, windDir=180, solar=3, humidity=65
+        data.extend_from_slice(&500i32.to_le_bytes());
+        data.extend_from_slice(&2i32.to_le_bytes());
+        data.extend_from_slice(&180i32.to_le_bytes());
+        data.extend_from_slice(&3i32.to_le_bytes());
+        data.extend_from_slice(&65i32.to_le_bytes());
+        // temp=21.5, perceivedTemp=20.0, dewPoint=15.0, precip=0.0, wind=3.5, pressure=1013.25
+        data.extend_from_slice(&21.5f64.to_le_bytes());
+        data.extend_from_slice(&20.0f64.to_le_bytes());
+        data.extend_from_slice(&15.0f64.to_le_bytes());
+        data.extend_from_slice(&0.0f64.to_le_bytes());
+        data.extend_from_slice(&3.5f64.to_le_bytes());
+        data.extend_from_slice(&1013.25f64.to_le_bytes());
+
+        let events = parse_weather_states(&data).unwrap();
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            StateEvent::WeatherState {
+                last_update,
+                entries,
+                ..
+            } => {
+                assert_eq!(*last_update, 1000);
+                assert_eq!(entries.len(), 1);
+                assert_eq!(entries[0].temperature, 21.5);
+                assert_eq!(entries[0].wind_direction, 180);
+                assert_eq!(entries[0].barometric_pressure, 1013.25);
+            }
+            _ => panic!("Expected WeatherState"),
+        }
+    }
+
+    #[test]
+    fn test_build_state_uuid_map() {
+        let structure = serde_json::json!({
+            "rooms": { "r1": { "name": "Kitchen" } },
+            "cats": { "c1": { "name": "Lighting" } },
+            "controls": {
+                "ctrl-uuid-1": {
+                    "name": "Kitchen Light",
+                    "type": "LightControllerV2",
+                    "room": "r1",
+                    "cat": "c1",
+                    "states": {
+                        "active": "state-active-uuid",
+                        "value": "state-value-uuid"
+                    },
+                    "subControls": {
+                        "sub-uuid-1": {
+                            "name": "Dimmer",
+                            "type": "Dimmer",
+                            "states": {
+                                "position": "state-dimmer-pos"
+                            }
+                        }
+                    }
+                }
+            },
+            "globalStates": {
+                "operatingMode": "global-op-mode-uuid"
+            },
+            "autopilot": {
+                "auto-uuid-1": {
+                    "name": "Evening Mode",
+                    "states": {
+                        "changed": "auto-changed-uuid"
+                    }
+                }
+            }
+        });
+
+        let map = build_state_uuid_map(&structure);
+
+        // Control states
+        let active = map.get("state-active-uuid").unwrap();
+        assert_eq!(active.control_name, "Kitchen Light");
+        assert_eq!(active.state_name, "active");
+        assert_eq!(active.control_type, "LightControllerV2");
+        assert_eq!(active.room.as_deref(), Some("Kitchen"));
+        assert_eq!(active.category.as_deref(), Some("Lighting"));
+
+        // Sub-control states
+        let dimmer = map.get("state-dimmer-pos").unwrap();
+        assert_eq!(dimmer.control_name, "Kitchen Light/Dimmer");
+        assert_eq!(dimmer.state_name, "position");
+
+        // Global states
+        let global = map.get("global-op-mode-uuid").unwrap();
+        assert_eq!(global.control_name, "Global");
+        assert_eq!(global.state_name, "operatingMode");
+        assert_eq!(global.control_type, "GlobalState");
+
+        // Autopilot states
+        let auto = map.get("auto-changed-uuid").unwrap();
+        assert_eq!(auto.control_name, "Evening Mode");
+        assert_eq!(auto.control_type, "AutopilotRule");
+    }
+
+    #[test]
+    fn test_build_state_uuid_map_empty_structure() {
+        let structure = serde_json::json!({
+            "rooms": {},
+            "controls": {}
+        });
+        let map = build_state_uuid_map(&structure);
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn test_parse_binary_payload_unknown_type() {
+        let events = parse_binary_payload(0xFF, &[]).unwrap();
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn test_parse_binary_payload_keepalive() {
+        let events = parse_binary_payload(MSG_KEEPALIVE, &[]).unwrap();
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0], StateEvent::Keepalive));
+    }
+
+    #[test]
+    fn test_parse_binary_payload_out_of_service() {
+        let events = parse_binary_payload(MSG_OUT_OF_SERVICE, &[]).unwrap();
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0], StateEvent::OutOfService));
+    }
+}


### PR DESCRIPTION
## Summary

- Add `src/stream.rs`: Loxone WebSocket binary protocol parser supporting all message types (Value-State 0x02, Text-State 0x03, Daytimer 0x04, Weather 0x07, Keepalive 0x06, Out-of-Service 0x05)
- Add state UUID → control metadata mapping from the structure cache (controls, sub-controls, global states, autopilot rules)
- Add `lox stream` command for real-time state change streaming via WebSocket with `--room`, `--type`, `--control` filters and `--json` NDJSON output
- Foundation for `lox otel` (OpenTelemetry exporter, #51)

## Test plan

- [x] All 83 tests pass (16 new tests for binary protocol parsing and state UUID mapping)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo build --release` succeeds
- [ ] Manual test with real Miniserver: `lox stream --json`
- [ ] Manual test with filters: `lox stream --room "Kitchen" --type Light`

Closes #35