### PR TITLE
OpenTelemetry exporter: lox otel serve/push

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -300,6 +300,25 @@ lox stream --json                      # output as NDJSON (one JSON object per l
 
 ---
 
+## OpenTelemetry Export
+
+```bash
+# Continuous daemon — push metrics via OTLP every 30s
+lox otel serve --endpoint http://localhost:4318 --interval 30s
+
+# With auth header (Dynatrace, Datadog, etc.)
+lox otel serve --endpoint https://otlp.example.com:4318 \
+  --header "Authorization=Bearer xxx" --interval 1m
+
+# Filter by room or control type
+lox otel serve --endpoint ... --room "Kitchen" --type LightControllerV2
+
+# One-shot push (for cron jobs)
+lox otel push --endpoint http://localhost:4318
+```
+
+---
+
 ## Firmware Update
 
 ```bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -910,6 +910,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1613,6 +1624,9 @@ dependencies = [
  "hex",
  "hmac",
  "httpmock",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "quick-xml",
  "rand 0.8.5",
  "reqwest",
@@ -1763,6 +1777,78 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "opentelemetry"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 1.4.0",
+ "opentelemetry",
+ "reqwest",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2366db2dca4d2ad033cad11e6ee42844fd727007af5ad04a1730f4cb8163bf"
+dependencies = [
+ "http 1.4.0",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.9.2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1846,6 +1932,26 @@ name = "pico-args"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
+name = "pin-project"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1958,6 +2064,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2820,6 +2949,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project",
+ "sync_wrapper",
+ "tokio-stream",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2871,7 +3032,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,11 @@ chrono = { version = "0.4", features = ["clock"] }
 byteorder = "1"
 uuid = { version = "1", features = ["v4"] }
 
+# OpenTelemetry deps
+opentelemetry = { version = "0.31", default-features = false, features = ["metrics"] }
+opentelemetry_sdk = { version = "0.31", default-features = false, features = ["metrics", "rt-tokio"] }
+opentelemetry-otlp = { version = "0.31", default-features = false, features = ["metrics", "http-proto", "reqwest-blocking-client"] }
+
 # Backup deps
 suppaftp = "6"
 zip = "2"

--- a/README.md
+++ b/README.md
@@ -125,7 +125,8 @@ lox blind "Beschattung Süd" pos 50     # Blind to 50%
 lox light mood "Licht" plus            # Next light mood
 lox thermostat "Heizung" temp 22.5     # Set temperature
 lox alarm "Alarmanlage" arm            # Arm alarm
-lox stream --room "Kitchen" --json     # Real-time WebSocket state stream
+lox stream --room "Kitchen" -o json    # Real-time WebSocket state stream
+lox otel serve --endpoint http://..   # Push metrics via OpenTelemetry
 lox if "Temperatur" gt 25 && echo hot  # Conditional logic
 lox status --energy                    # Energy dashboard
 lox config download --extract          # Download & extract Loxone Config

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod config;
 mod ftp;
 mod loxcc;
 mod loxone_xml;
+mod otel;
 mod scene;
 mod stream;
 mod token;
@@ -124,6 +125,7 @@ System:
   discover, extensions         Find Miniservers, list extensions
   update, reboot               Firmware updates, reboot
   files                        Browse Miniserver filesystem
+  otel                         Export metrics via OpenTelemetry (OTLP)
 
 Configuration:
   setup, alias, scene          Connection settings, aliases, scenes
@@ -514,6 +516,12 @@ enum Cmd {
         action: FilesCmd,
     },
 
+    /// Export metrics & logs to OpenTelemetry backends
+    Otel {
+        #[command(subcommand)]
+        action: OtelCmd,
+    },
+
     // ── Configuration ────────────────────────────────────────────────────────
     /// Configure connection settings
     Setup {
@@ -706,6 +714,43 @@ enum FilesCmd {
         /// Local output path (defaults to filename)
         #[arg(long, value_name = "PATH")]
         save_as: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
+enum OtelCmd {
+    /// Continuously push metrics to an OTLP endpoint
+    Serve {
+        /// OTLP HTTP endpoint URL (e.g. http://localhost:4318)
+        #[arg(long, default_value = "http://localhost:4318")]
+        endpoint: String,
+        /// Push interval (e.g. 30s, 1m, 5m)
+        #[arg(long, short = 'i', default_value = "30s")]
+        interval: String,
+        /// Filter by control type
+        #[arg(long, short = 't')]
+        r#type: Option<String>,
+        /// Filter by room
+        #[arg(long, short = 'r')]
+        room: Option<String>,
+        /// Additional header for auth (e.g. "Authorization=Bearer xxx")
+        #[arg(long)]
+        header: Vec<String>,
+    },
+    /// One-shot: push current state and exit
+    Push {
+        /// OTLP HTTP endpoint URL
+        #[arg(long, default_value = "http://localhost:4318")]
+        endpoint: String,
+        /// Filter by control type
+        #[arg(long, short = 't')]
+        r#type: Option<String>,
+        /// Filter by room
+        #[arg(long, short = 'r')]
+        room: Option<String>,
+        /// Additional header for auth
+        #[arg(long)]
+        header: Vec<String>,
     },
 }
 
@@ -2684,10 +2729,11 @@ fn main() -> Result<()> {
             let mut lox = LoxClient::new(cfg.clone());
             let structure = lox.get_structure()?.clone();
             let state_map = stream::build_state_uuid_map(&structure);
-            let json = cli.json;
-
             if !quiet {
                 eprintln!("Streaming state changes (Ctrl+C to stop)...");
+            }
+            if csv && !no_header {
+                println!("timestamp,control,state,value,room,type,uuid");
             }
 
             let type_filter = r#type;
@@ -2714,6 +2760,7 @@ fn main() -> Result<()> {
                                 }
                                 print_stream_event(
                                     json,
+                                    csv,
                                     &info.control_name,
                                     &info.state_name,
                                     &format!("{}", value),
@@ -2738,6 +2785,7 @@ fn main() -> Result<()> {
                                 }
                                 print_stream_event(
                                     json,
+                                    csv,
                                     &info.control_name,
                                     &info.state_name,
                                     text,
@@ -3618,6 +3666,45 @@ fn main() -> Result<()> {
                 println!("{}", line);
             }
         }
+
+        Cmd::Otel { action } => {
+            let cfg = Config::load()?;
+            match action {
+                OtelCmd::Serve {
+                    endpoint,
+                    interval,
+                    r#type,
+                    room,
+                    header,
+                } => {
+                    let interval = otel::parse_interval(&interval)?;
+                    otel::serve(
+                        &cfg,
+                        &endpoint,
+                        interval,
+                        r#type.as_deref(),
+                        room.as_deref(),
+                        &header,
+                        quiet,
+                    )?;
+                }
+                OtelCmd::Push {
+                    endpoint,
+                    r#type,
+                    room,
+                    header,
+                } => {
+                    otel::push(
+                        &cfg,
+                        &endpoint,
+                        r#type.as_deref(),
+                        room.as_deref(),
+                        &header,
+                        quiet,
+                    )?;
+                }
+            }
+        }
     }
 
     Ok(())
@@ -3663,8 +3750,10 @@ fn matches_filters(
     true
 }
 
+#[allow(clippy::too_many_arguments)]
 fn print_stream_event(
     json: bool,
+    csv: bool,
     control: &str,
     state: &str,
     value: &str,
@@ -3684,6 +3773,17 @@ fn print_stream_event(
                 "type": control_type,
                 "uuid": uuid,
             })
+        );
+    } else if csv {
+        println!(
+            "{},{},{},{},{},{},{}",
+            chrono::Local::now().to_rfc3339(),
+            control,
+            state,
+            value,
+            room.unwrap_or(""),
+            control_type,
+            uuid,
         );
     } else {
         println!(

--- a/src/otel.rs
+++ b/src/otel.rs
@@ -1,0 +1,509 @@
+//! OpenTelemetry exporter — pushes Loxone metrics via OTLP to any backend.
+//!
+//! Supports both continuous daemon mode (`lox otel serve`) and one-shot push
+//! (`lox otel push`). Uses WebSocket streaming for real-time control state
+//! updates, plus HTTP polling for system/network diagnostics.
+
+use anyhow::{bail, Result};
+use opentelemetry::metrics::MeterProvider as _;
+use opentelemetry::KeyValue;
+use opentelemetry_otlp::MetricExporter;
+use opentelemetry_otlp::{Protocol, WithExportConfig, WithHttpConfig};
+use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
+use opentelemetry_sdk::Resource;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use crate::client::LoxClient;
+use crate::config::Config;
+use crate::stream::{self, StateEvent, StateUuidInfo};
+
+// ── Interval parsing ────────────────────────────────────────────────────────
+
+/// Parse a human-friendly duration string (e.g. "30s", "5m", "1h").
+pub fn parse_interval(s: &str) -> Result<Duration> {
+    let s = s.trim();
+    if let Some(n) = s.strip_suffix('s') {
+        Ok(Duration::from_secs(n.parse()?))
+    } else if let Some(n) = s.strip_suffix('m') {
+        Ok(Duration::from_secs(n.parse::<u64>()? * 60))
+    } else if let Some(n) = s.strip_suffix('h') {
+        Ok(Duration::from_secs(n.parse::<u64>()? * 3600))
+    } else {
+        // Assume seconds if no suffix
+        Ok(Duration::from_secs(s.parse()?))
+    }
+}
+
+// ── OTLP exporter setup ────────────────────────────────────────────────────
+
+/// Parse header strings like "Authorization=Bearer xxx" into (key, value) pairs.
+fn parse_headers(headers: &[String]) -> Result<HashMap<String, String>> {
+    let mut map = HashMap::new();
+    for h in headers {
+        if let Some((k, v)) = h.split_once('=') {
+            map.insert(k.to_string(), v.to_string());
+        } else {
+            bail!("Invalid header format '{}'. Expected 'Key=Value'.", h);
+        }
+    }
+    Ok(map)
+}
+
+/// Build an OTLP metric exporter with the given endpoint and headers.
+fn build_exporter(endpoint: &str, headers: &[String]) -> Result<MetricExporter> {
+    let header_map = parse_headers(headers)?;
+    let mut builder = MetricExporter::builder()
+        .with_http()
+        .with_protocol(Protocol::HttpBinary)
+        .with_endpoint(endpoint);
+    if !header_map.is_empty() {
+        builder = builder.with_headers(header_map);
+    }
+    builder
+        .build()
+        .map_err(|e| anyhow::anyhow!("Failed to build OTLP exporter: {}", e))
+}
+
+/// Build the OTel resource with Miniserver metadata.
+fn build_resource(cfg: &Config) -> Resource {
+    let mut attrs = vec![
+        KeyValue::new("service.name", "loxone-miniserver"),
+        KeyValue::new("service.version", env!("CARGO_PKG_VERSION")),
+        KeyValue::new("host.name", cfg.host.clone()),
+    ];
+    if !cfg.serial.is_empty() {
+        attrs.push(KeyValue::new("device.id", cfg.serial.clone()));
+    }
+    Resource::builder().with_attributes(attrs).build()
+}
+
+// ── Metric recording ────────────────────────────────────────────────────────
+
+/// Shared state for the latest values from WebSocket streaming.
+type StateStore = Arc<Mutex<HashMap<String, (StateUuidInfo, f64)>>>;
+
+/// Record system diagnostics (CPU, heap, tasks, etc.) as metrics.
+fn record_system_metrics(lox: &LoxClient, meter: &opentelemetry::metrics::Meter) -> Result<()> {
+    // Heap
+    if let Ok(text) = lox.get_text("/dev/sys/heap") {
+        if let Some(val) = extract_lox_value(&text) {
+            let gauge = meter.f64_gauge("loxone.system.heap_bytes").build();
+            gauge.record(val, &[]);
+        }
+    }
+
+    // CPU (admin only — may fail)
+    if let Ok(text) = lox.get_text("/jdev/sys/lastcpu") {
+        if let Some(val) = extract_lox_value(&text) {
+            let gauge = meter.f64_gauge("loxone.system.cpu_percent").build();
+            gauge.record(val, &[]);
+        }
+    }
+
+    // Tasks
+    if let Ok(text) = lox.get_text("/jdev/sys/numtasks") {
+        if let Some(val) = extract_lox_value(&text) {
+            let gauge = meter.f64_gauge("loxone.system.tasks_count").build();
+            gauge.record(val, &[]);
+        }
+    }
+
+    // Context switches
+    if let Ok(text) = lox.get_text("/jdev/sys/contextswitches") {
+        if let Some(val) = extract_lox_value(&text) {
+            let gauge = meter.f64_gauge("loxone.system.context_switches").build();
+            gauge.record(val, &[]);
+        }
+    }
+
+    Ok(())
+}
+
+/// Record CAN bus and LAN network metrics.
+fn record_network_metrics(lox: &LoxClient, meter: &opentelemetry::metrics::Meter) -> Result<()> {
+    let can_metrics = [
+        ("/jdev/bus/packetssent", "loxone.can.packets_sent"),
+        ("/jdev/bus/packetsreceived", "loxone.can.packets_received"),
+        ("/jdev/bus/receiveerrors", "loxone.can.receive_errors"),
+        ("/jdev/bus/frameerrors", "loxone.can.frame_errors"),
+        ("/jdev/bus/overruns", "loxone.can.overruns"),
+    ];
+    for (path, name) in &can_metrics {
+        if let Ok(text) = lox.get_text(path) {
+            if let Some(val) = extract_lox_value(&text) {
+                let gauge = meter.f64_gauge(*name).build();
+                gauge.record(val, &[]);
+            }
+        }
+    }
+
+    let lan_metrics = [
+        ("/jdev/lan/txp", "loxone.lan.tx_packets"),
+        ("/jdev/lan/txe", "loxone.lan.tx_errors"),
+        ("/jdev/lan/txc", "loxone.lan.tx_collisions"),
+        ("/jdev/lan/rxp", "loxone.lan.rx_packets"),
+        ("/jdev/lan/rxo", "loxone.lan.rx_overflow"),
+        ("/jdev/lan/eof", "loxone.lan.eof_errors"),
+    ];
+    for (path, name) in &lan_metrics {
+        if let Ok(text) = lox.get_text(path) {
+            if let Some(val) = extract_lox_value(&text) {
+                let gauge = meter.f64_gauge(*name).build();
+                gauge.record(val, &[]);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Record the latest control state values as OTel gauge metrics.
+fn record_control_metrics(
+    store: &StateStore,
+    meter: &opentelemetry::metrics::Meter,
+    type_filter: Option<&str>,
+    room_filter: Option<&str>,
+) {
+    let state = store.lock().unwrap();
+    let gauge = meter.f64_gauge("loxone.control.value").build();
+
+    for (uuid, (info, value)) in state.iter() {
+        if let Some(tf) = type_filter {
+            if !info
+                .control_type
+                .to_lowercase()
+                .contains(&tf.to_lowercase())
+            {
+                continue;
+            }
+        }
+        if let Some(rf) = room_filter {
+            if !info
+                .room
+                .as_deref()
+                .unwrap_or("")
+                .to_lowercase()
+                .contains(&rf.to_lowercase())
+            {
+                continue;
+            }
+        }
+
+        let attrs = [
+            KeyValue::new("control.name", info.control_name.clone()),
+            KeyValue::new("control.type", info.control_type.clone()),
+            KeyValue::new("control.uuid", uuid.clone()),
+            KeyValue::new("state.name", info.state_name.clone()),
+            KeyValue::new("control.room", info.room.clone().unwrap_or_default()),
+            KeyValue::new(
+                "control.category",
+                info.category.clone().unwrap_or_default(),
+            ),
+        ];
+        gauge.record(*value, &attrs);
+    }
+}
+
+/// Extract a numeric value from Loxone XML/JSON response.
+/// Handles both JSON `{"LL":{"value":"42"}}` and plain XML `value="42"` formats.
+fn extract_lox_value(text: &str) -> Option<f64> {
+    // Try JSON first
+    if let Ok(v) = serde_json::from_str::<serde_json::Value>(text) {
+        if let Some(val) = v.pointer("/LL/value").and_then(|v| v.as_str()) {
+            return val.parse().ok();
+        }
+    }
+    // Try XML attribute
+    let key = "value=\"";
+    if let Some(start) = text.find(key) {
+        let rest = &text[start + key.len()..];
+        if let Some(end) = rest.find('"') {
+            return rest[..end].parse().ok();
+        }
+    }
+    None
+}
+
+// ── Serve (continuous daemon) ───────────────────────────────────────────────
+
+/// Run the OTel exporter in continuous mode:
+/// - Connect to Miniserver WebSocket for real-time state changes
+/// - Push metrics via OTLP at the configured interval
+/// - Also fetch system/network diagnostics on each interval
+pub fn serve(
+    cfg: &Config,
+    endpoint: &str,
+    interval: Duration,
+    type_filter: Option<&str>,
+    room_filter: Option<&str>,
+    headers: &[String],
+    quiet: bool,
+) -> Result<()> {
+    let exporter = build_exporter(endpoint, headers)?;
+    let reader = PeriodicReader::builder(exporter)
+        .with_interval(interval)
+        .build();
+    let provider = SdkMeterProvider::builder()
+        .with_resource(build_resource(cfg))
+        .with_reader(reader)
+        .build();
+
+    // Load structure for UUID mapping
+    let mut lox = LoxClient::new(cfg.clone());
+    let structure = lox.get_structure()?.clone();
+    let state_map = stream::build_state_uuid_map(&structure);
+
+    // Shared state store updated by WebSocket, read by metric callbacks
+    let store: StateStore = Arc::new(Mutex::new(HashMap::new()));
+    let store_ws = Arc::clone(&store);
+
+    if !quiet {
+        eprintln!(
+            "Pushing metrics to {} every {}s (Ctrl+C to stop)...",
+            endpoint,
+            interval.as_secs()
+        );
+    }
+
+    let tf = type_filter.map(|s| s.to_string());
+    let rf = room_filter.map(|s| s.to_string());
+
+    // Spawn system metrics polling on a separate thread
+    let cfg_sys = cfg.clone();
+    let meter_sys = provider.meter("loxone");
+    let tf_sys = tf.clone();
+    let rf_sys = rf.clone();
+    let store_sys = Arc::clone(&store);
+    std::thread::spawn(move || {
+        let lox = LoxClient::new(cfg_sys);
+        loop {
+            // Record system diagnostics
+            let _ = record_system_metrics(&lox, &meter_sys);
+            let _ = record_network_metrics(&lox, &meter_sys);
+
+            // Record control state gauges from the shared store
+            record_control_metrics(&store_sys, &meter_sys, tf_sys.as_deref(), rf_sys.as_deref());
+
+            std::thread::sleep(interval);
+        }
+    });
+
+    // WebSocket streaming on the main async runtime
+    let rt = tokio::runtime::Runtime::new()?;
+    rt.block_on(stream::stream_events(cfg, |events| {
+        let mut state = store_ws.lock().unwrap();
+        for event in &events {
+            if let StateEvent::ValueState { uuid, value } = event {
+                if let Some(info) = state_map.get(uuid) {
+                    state.insert(uuid.clone(), (info.clone(), *value));
+                }
+            }
+        }
+        Ok(())
+    }))?;
+
+    // Graceful shutdown
+    provider
+        .shutdown()
+        .map_err(|e| anyhow::anyhow!("OTel shutdown: {}", e))?;
+
+    Ok(())
+}
+
+// ── Push (one-shot) ─────────────────────────────────────────────────────────
+
+/// Push current state once and exit. Connects to WebSocket, collects the
+/// initial state dump, fetches system metrics, pushes everything, and exits.
+pub fn push(
+    cfg: &Config,
+    endpoint: &str,
+    type_filter: Option<&str>,
+    room_filter: Option<&str>,
+    headers: &[String],
+    quiet: bool,
+) -> Result<()> {
+    let exporter = build_exporter(endpoint, headers)?;
+    let reader = PeriodicReader::builder(exporter)
+        .with_interval(Duration::from_secs(1))
+        .build();
+    let provider = SdkMeterProvider::builder()
+        .with_resource(build_resource(cfg))
+        .with_reader(reader)
+        .build();
+    let meter = provider.meter("loxone");
+
+    // Load structure for UUID mapping
+    let mut lox = LoxClient::new(cfg.clone());
+    let structure = lox.get_structure()?.clone();
+    let state_map = stream::build_state_uuid_map(&structure);
+
+    if !quiet {
+        eprintln!("Collecting current state...");
+    }
+
+    // Collect initial state dump via WebSocket with a timeout.
+    // After subscribing, the Miniserver sends a full dump of all states,
+    // then switches to incremental updates. We collect for a few seconds
+    // to capture the full dump, then disconnect.
+    let store: StateStore = Arc::new(Mutex::new(HashMap::new()));
+    let store_ws = Arc::clone(&store);
+
+    let rt = tokio::runtime::Runtime::new()?;
+    let collect_result = rt.block_on(async {
+        tokio::time::timeout(
+            Duration::from_secs(10),
+            stream::stream_events(cfg, |events| {
+                let mut state = store_ws.lock().unwrap();
+                let mut collected = false;
+                for event in &events {
+                    if let StateEvent::ValueState { uuid, value } = event {
+                        if let Some(info) = state_map.get(uuid) {
+                            state.insert(uuid.clone(), (info.clone(), *value));
+                            collected = true;
+                        }
+                    }
+                }
+                // After we've collected the initial dump (first batch of value states),
+                // check if we already have enough. The initial dump is complete when
+                // we've received at least some states.
+                if collected && !state.is_empty() {
+                    // Signal to stop by returning an error (stream_events will propagate it)
+                    // We use a custom error type to distinguish "done collecting" from real errors
+                    return Err(anyhow::anyhow!("__done_collecting__"));
+                }
+                Ok(())
+            }),
+        )
+        .await
+    });
+
+    // The "done collecting" error is expected — it means we got the initial dump.
+    // WebSocket auth failures are non-fatal: we still push system metrics via HTTP.
+    match collect_result {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) if e.to_string().contains("__done_collecting__") => {}
+        Ok(Err(e)) => {
+            if !quiet {
+                eprintln!("Warning: WebSocket streaming failed: {}", e);
+                eprintln!("Falling back to system metrics only (no control states).");
+            }
+        }
+        Err(_) => {} // Timeout — collected what we could
+    }
+
+    // Record system metrics
+    let _ = record_system_metrics(&lox, &meter);
+    let _ = record_network_metrics(&lox, &meter);
+
+    // Record control metrics from collected state
+    record_control_metrics(&store, &meter, type_filter, room_filter);
+
+    if !quiet {
+        let count = store.lock().unwrap().len();
+        eprintln!(
+            "Pushing {} control states + system metrics to {}...",
+            count, endpoint
+        );
+    }
+
+    // Wait for the periodic reader to complete at least one export cycle,
+    // then shut down (which does a final flush).
+    std::thread::sleep(Duration::from_secs(2));
+
+    // Shutdown may fail if no metrics were recorded (empty flush) — non-fatal
+    let _ = provider.shutdown();
+
+    if !quiet {
+        eprintln!("Done.");
+    }
+
+    Ok(())
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_interval_seconds() {
+        assert_eq!(parse_interval("30s").unwrap(), Duration::from_secs(30));
+        assert_eq!(parse_interval("1s").unwrap(), Duration::from_secs(1));
+    }
+
+    #[test]
+    fn test_parse_interval_minutes() {
+        assert_eq!(parse_interval("5m").unwrap(), Duration::from_secs(300));
+        assert_eq!(parse_interval("1m").unwrap(), Duration::from_secs(60));
+    }
+
+    #[test]
+    fn test_parse_interval_hours() {
+        assert_eq!(parse_interval("2h").unwrap(), Duration::from_secs(7200));
+    }
+
+    #[test]
+    fn test_parse_interval_no_suffix() {
+        assert_eq!(parse_interval("60").unwrap(), Duration::from_secs(60));
+    }
+
+    #[test]
+    fn test_parse_interval_whitespace() {
+        assert_eq!(parse_interval(" 30s ").unwrap(), Duration::from_secs(30));
+    }
+
+    #[test]
+    fn test_parse_interval_invalid() {
+        assert!(parse_interval("abc").is_err());
+        assert!(parse_interval("").is_err());
+    }
+
+    #[test]
+    fn test_parse_headers() {
+        let headers = vec![
+            "Authorization=Bearer token123".to_string(),
+            "X-Custom=value".to_string(),
+        ];
+        let map = parse_headers(&headers).unwrap();
+        assert_eq!(map.get("Authorization").unwrap(), "Bearer token123");
+        assert_eq!(map.get("X-Custom").unwrap(), "value");
+    }
+
+    #[test]
+    fn test_parse_headers_invalid() {
+        let headers = vec!["no-equals-sign".to_string()];
+        assert!(parse_headers(&headers).is_err());
+    }
+
+    #[test]
+    fn test_extract_lox_value_json() {
+        let text = r#"{"LL":{"value":"42.5","Code":"200"}}"#;
+        assert_eq!(extract_lox_value(text), Some(42.5));
+    }
+
+    #[test]
+    fn test_extract_lox_value_xml() {
+        let text = r#"<LL value="21.5" />"#;
+        assert_eq!(extract_lox_value(text), Some(21.5));
+    }
+
+    #[test]
+    fn test_extract_lox_value_none() {
+        assert_eq!(extract_lox_value("no value here"), None);
+    }
+
+    #[test]
+    fn test_build_resource() {
+        let cfg = Config {
+            host: "https://192.168.1.100".to_string(),
+            serial: "SERIAL123".to_string(),
+            ..Default::default()
+        };
+        let resource = build_resource(&cfg);
+        // Resource is opaque, but we can verify it was created without panic
+        let _ = format!("{:?}", resource);
+    }
+}

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -4,13 +4,29 @@
 //! and yields structured state-change events. Used by `lox stream` and `lox otel`.
 
 use anyhow::{bail, Result};
+use cbc::cipher::{BlockEncryptMut, KeyIvInit};
 use futures_util::{SinkExt, StreamExt};
+use hmac::{Hmac, Mac};
+use rand::RngCore;
+use rsa::{pkcs8::DecodePublicKey, Pkcs1v15Encrypt, RsaPublicKey};
 use serde_json::Value;
+use sha1::Sha1 as Sha1Digest;
+use sha2::{Digest, Sha256};
 use std::collections::HashMap;
+use std::time::Duration;
 use tokio_tungstenite::tungstenite::Message;
 
 use crate::config::Config;
 use crate::ws::LoxWsClient;
+
+type HmacSha256 = Hmac<Sha256>;
+type Aes256CbcEnc = cbc::Encryptor<aes::Aes256>;
+
+fn aes_encrypt(key: &[u8], iv: &[u8], plaintext: &[u8]) -> Vec<u8> {
+    Aes256CbcEnc::new_from_slices(key, iv)
+        .expect("bad key/iv")
+        .encrypt_padded_vec_mut::<cbc::cipher::block_padding::Pkcs7>(plaintext)
+}
 
 // ── Binary message types ────────────────────────────────────────────────────
 
@@ -481,12 +497,193 @@ pub fn parse_binary_payload(msg_type: u8, data: &[u8]) -> Result<Vec<StateEvent>
 /// and call `handler` for each batch of state events.
 ///
 /// This function runs until the connection is closed or an error occurs.
+/// Authenticate on the WebSocket using RSA key exchange + AES encryption.
+/// This is required before any commands (like enablebinstatusupdate) are accepted.
+async fn ws_authenticate(
+    ws: &mut tokio_tungstenite::WebSocketStream<
+        tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+    >,
+    cfg: &Config,
+) -> Result<()> {
+    // 1. Fetch RSA public key via HTTP
+    let cfg2 = cfg.clone();
+    let pub_key_pem: String = tokio::task::spawn_blocking(move || -> Result<String> {
+        let client = reqwest::blocking::Client::builder()
+            .user_agent(crate::client::USER_AGENT)
+            .danger_accept_invalid_certs(true)
+            .build()?;
+        let resp: serde_json::Value = client
+            .get(format!("{}/jdev/sys/getPublicKey", cfg2.host))
+            .basic_auth(&cfg2.user, Some(&cfg2.pass))
+            .send()?
+            .json()?;
+        Ok(resp
+            .pointer("/LL/value")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow::anyhow!("no public key"))?
+            .to_string())
+    })
+    .await??;
+
+    // Parse RSA public key (Loxone mis-labels as CERTIFICATE)
+    let pub_key: RsaPublicKey = {
+        let b64: String = pub_key_pem
+            .replace("-----BEGIN CERTIFICATE-----", "")
+            .replace("-----END CERTIFICATE-----", "")
+            .replace("-----BEGIN PUBLIC KEY-----", "")
+            .replace("-----END PUBLIC KEY-----", "")
+            .chars()
+            .filter(|c| !c.is_whitespace())
+            .collect();
+        let mut pem = String::from("-----BEGIN PUBLIC KEY-----\n");
+        for chunk in b64.as_bytes().chunks(64) {
+            pem.push_str(std::str::from_utf8(chunk).unwrap_or(""));
+            pem.push('\n');
+        }
+        pem.push_str("-----END PUBLIC KEY-----");
+        RsaPublicKey::from_public_key_pem(&pem).map_err(|e| anyhow::anyhow!("RSA parse: {}", e))?
+    };
+
+    // 2. Generate AES-256 key + IV
+    let mut aes_key = [0u8; 32];
+    let mut aes_iv = [0u8; 16];
+    rand::thread_rng().fill_bytes(&mut aes_key);
+    rand::thread_rng().fill_bytes(&mut aes_iv);
+    let key_info = format!("{}:{}", hex::encode(aes_key), hex::encode(aes_iv));
+
+    // 3. RSA-encrypt key info
+    let encrypted_b64 = {
+        let enc = pub_key.encrypt(
+            &mut rand::thread_rng(),
+            Pkcs1v15Encrypt,
+            key_info.as_bytes(),
+        )?;
+        base64::Engine::encode(&base64::engine::general_purpose::STANDARD, &enc)
+    };
+
+    // 4. Get HMAC key for authentication
+    let cfg3 = cfg.clone();
+    let (sig, hash_alg) = tokio::task::spawn_blocking(move || -> Result<(String, String)> {
+        let client = reqwest::blocking::Client::builder()
+            .user_agent(crate::client::USER_AGENT)
+            .danger_accept_invalid_certs(true)
+            .build()?;
+        let resp: serde_json::Value = client
+            .get(format!("{}/jdev/sys/getkey2", cfg3.host))
+            .basic_auth(&cfg3.user, Some(&cfg3.pass))
+            .send()?
+            .json()?;
+        let val = resp
+            .pointer("/LL/value")
+            .ok_or_else(|| anyhow::anyhow!("no key2"))?;
+        let key_hex = val.get("key").and_then(|v| v.as_str()).unwrap_or("");
+        let salt_hex = val.get("salt").and_then(|v| v.as_str()).unwrap_or("");
+        let hash_alg = val
+            .get("hashAlg")
+            .and_then(|v| v.as_str())
+            .unwrap_or("SHA256")
+            .to_string();
+        let key_b = hex::decode(key_hex)?;
+        let salt = String::from_utf8(hex::decode(salt_hex)?)?;
+
+        let mut h1 = Sha1Digest::new();
+        h1.update(cfg3.pass.as_bytes());
+        let pass_sha1 = format!("{:X}", h1.finalize());
+        let visu = format!(
+            "{:X}",
+            Sha256::digest(format!("{}:{}", pass_sha1, salt).as_bytes())
+        );
+
+        let mut mac = HmacSha256::new_from_slice(&key_b)?;
+        mac.update(format!("{}:{}", cfg3.user, visu).as_bytes());
+        Ok((hex::encode(mac.finalize().into_bytes()), hash_alg))
+    })
+    .await??;
+
+    // 5. Key exchange
+    ws.send(Message::Text(format!(
+        "jdev/sys/keyexchange/{}",
+        encrypted_b64
+    )))
+    .await?;
+
+    // Read keyexchange response
+    for _ in 0..5 {
+        match tokio::time::timeout(Duration::from_secs(5), ws.next()).await {
+            Ok(Some(Ok(Message::Text(t)))) => {
+                let v: serde_json::Value = serde_json::from_str(&t).unwrap_or_default();
+                let code = v
+                    .pointer("/LL/Code")
+                    .and_then(|c| c.as_str())
+                    .unwrap_or("0");
+                if code != "200" {
+                    bail!("keyexchange failed ({}): {}", code, t);
+                }
+                break;
+            }
+            Ok(Some(Ok(Message::Binary(_)))) => continue,
+            Ok(Some(Err(e))) => bail!("WS error: {}", e),
+            _ => bail!("WS timeout/closed during keyexchange"),
+        }
+    }
+
+    // 6. Authenticate via encrypted gettoken (same as token.rs)
+    let _hash_alg = hash_alg;
+    let client_uuid = uuid::Uuid::new_v4().to_string();
+    let cmd = format!(
+        "jdev/sys/gettoken/{}/{}/4/{}/lox-cli",
+        sig, cfg.user, client_uuid
+    );
+    let enc_cmd = aes_encrypt(&aes_key, &aes_iv, cmd.as_bytes());
+    let enc_b64 = base64::Engine::encode(&base64::engine::general_purpose::STANDARD, &enc_cmd);
+    let enc_url: String = enc_b64
+        .chars()
+        .map(|c| match c {
+            '+' => "%2B".to_string(),
+            '/' => "%2F".to_string(),
+            '=' => "%3D".to_string(),
+            c => c.to_string(),
+        })
+        .collect();
+    ws.send(Message::Text(format!("jdev/sys/enc/{}", enc_url)))
+        .await?;
+
+    // Read auth response
+    for _ in 0..10 {
+        match tokio::time::timeout(Duration::from_secs(5), ws.next()).await {
+            Ok(Some(Ok(Message::Text(t)))) => {
+                let v: serde_json::Value = serde_json::from_str(&t).unwrap_or_default();
+                let code = v
+                    .pointer("/LL/Code")
+                    .and_then(|c| c.as_str())
+                    .unwrap_or("0");
+                if code == "200" {
+                    return Ok(());
+                }
+                if code != "0" {
+                    bail!("WebSocket authentication failed ({}): {}", code, t);
+                }
+            }
+            Ok(Some(Ok(Message::Binary(_)))) => continue,
+            Ok(Some(Err(e))) => bail!("WS error: {}", e),
+            _ => bail!("WS timeout waiting for auth response"),
+        }
+    }
+
+    bail!("WebSocket authentication: no response after 10 messages")
+}
+
 pub async fn stream_events<F>(cfg: &Config, mut handler: F) -> Result<()>
 where
     F: FnMut(Vec<StateEvent>) -> Result<()>,
 {
     let ws_client = LoxWsClient::new(cfg.clone());
     let (mut ws_stream, _resp) = ws_client.connect_raw().await?;
+
+    // Authenticate on the WebSocket before subscribing.
+    // The Miniserver requires a key exchange + encrypted auth on WebSocket,
+    // even if HTTP basic auth was in the upgrade header.
+    ws_authenticate(&mut ws_stream, cfg).await?;
 
     // Subscribe to binary status updates
     ws_stream
@@ -521,6 +718,12 @@ where
                         if !events.is_empty() {
                             handler(events)?;
                         }
+                    } else if data.len() > 8 {
+                        // Header + payload in the same frame
+                        let events = parse_binary_payload(header.msg_type, &data[8..])?;
+                        if !events.is_empty() {
+                            handler(events)?;
+                        }
                     } else {
                         pending_header = Some(header);
                     }
@@ -528,8 +731,6 @@ where
             }
             Message::Text(_) => {
                 // Text responses (command ACKs, etc.) — skip for streaming
-                // Clear pending header if any, since text messages aren't payloads
-                // for binary headers
             }
             Message::Ping(data) => {
                 ws_stream.send(Message::Pong(data)).await?;


### PR DESCRIPTION
## Summary

- Add `lox otel serve` for continuous metric push via OTLP at configurable intervals
- Add `lox otel push` for one-shot metric collection and export
- Supports any OTLP-compatible backend (Dynatrace, Datadog, Grafana Cloud, New Relic, Elastic, etc.)
- Custom auth headers via `--header "Authorization=Bearer xxx"`
- Filter by `--room` and `--type`
- Graceful fallback: if WebSocket auth fails, still pushes system/network metrics via HTTP

### Metrics exported

| Metric | Source |
|--------|--------|
| `loxone.control.value` | WebSocket state stream (per control, with room/type/category labels) |
| `loxone.system.heap_bytes` | HTTP `/dev/sys/heap` |
| `loxone.system.cpu_percent` | HTTP `/jdev/sys/lastcpu` |
| `loxone.system.tasks_count` | HTTP `/jdev/sys/numtasks` |
| `loxone.system.context_switches` | HTTP `/jdev/sys/contextswitches` |
| `loxone.can.*` | HTTP CAN bus statistics (5 metrics) |
| `loxone.lan.*` | HTTP LAN statistics (6 metrics) |

### Also includes

- WebSocket RSA/AES authentication flow in `src/stream.rs` (required for Gen 2 Miniservers)
- Binary header+payload in single frame handling (some Miniservers combine them)
- CSV output support for `lox stream`

### Dependencies added

- `opentelemetry` 0.31 (metrics only)
- `opentelemetry_sdk` 0.31 (metrics + rt-tokio)
- `opentelemetry-otlp` 0.31 (HTTP protobuf transport, reqwest blocking client)

## Test plan

- [x] All 95 tests pass (12 new tests for OTel interval parsing, header parsing, value extraction)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo build --release` succeeds
- [x] End-to-end test: `lox otel push --endpoint http://localhost:4318` → OTel Collector received metrics
- [x] End-to-end test with WebSocket streaming (requires token auth configured on Miniserver)

Closes #51