### PR TITLE
Fix HTTP 401: don't use WS token as basic auth password

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -78,11 +78,10 @@ impl LoxClient {
         &self,
         rb: reqwest::blocking::RequestBuilder,
     ) -> reqwest::blocking::RequestBuilder {
-        if let Some(ts) = TokenStore::load().filter(|t| t.is_valid()) {
-            rb.basic_auth(&self.cfg.user, Some(&ts.token))
-        } else {
-            rb.basic_auth(&self.cfg.user, Some(&self.cfg.pass))
-        }
+        // Always use password for HTTP basic auth.
+        // Loxone tokens are for WebSocket auth only — they can't be
+        // used as HTTP basic auth passwords.
+        rb.basic_auth(&self.cfg.user, Some(&self.cfg.pass))
     }
 
     pub fn get_text(&self, path: &str) -> Result<String> {


### PR DESCRIPTION
## Summary

`apply_auth()` was using the stored WebSocket token as the HTTP basic auth password when a valid token existed. Loxone tokens are for WebSocket authentication only — using them as HTTP passwords causes 401 on all API endpoints (`lox sensors`, `lox get`, etc.).

This regression was exposed after PR #54 fixed WS auth, causing `lox token fetch` to succeed for the first time. Before that, no token was ever stored, so `apply_auth` always used the password.

## Test plan

- [x] `cargo test` — 97 tests pass
- [x] `lox sensors` — shows actual values instead of `?`
- [x] `lox get Balkonkraftwerk` — returns sensor data