### PR TITLE
Bump version to 0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1609,7 +1609,7 @@ dependencies = [
 
 [[package]]
 name = "lox"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lox"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "Loxone Miniserver CLI — control lights, blinds, and more from your terminal"
 repository = "https://github.com/discostu105/lox"


### PR DESCRIPTION
## Summary
- Bugfix release v0.6.1

## Changes included (already on main)
- Fix cross-origin redirect on Gen 2 Miniservers (#59)
- Add `-v`/`--verbose` flag for HTTP debugging
- Fix UTF-8 panic in verbose body truncation
- Fix host parsing edge case in redirect policy
- Fix credential redaction for duplicate query params

https://claude.ai/code/session_01RMPw3hkD5JdFDCv44Gz54Z