### PR TITLE
docs: update docs for recent PRs (#60, #67, #68, #69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `lox health` — device health dashboard showing battery, signal, offline status, and bus errors for Tree/Air devices (`--type tree|air`, `--problems`)
+- `lox schema` — command schema introspection for AI agent discovery; lists commands with metadata, args, and valid actions
+- `--dry-run` global flag — validates and resolves inputs without executing commands; returns structured JSON envelope with `-o json`
+- `--non-interactive` global flag — fails instead of prompting for confirmation (implied by `-o json`)
+- `--trace-id` global flag — correlation ID for tracking agent actions in logs
+- `-v`/`--verbose` global flag — `-v` shows HTTP requests, `-vv` shows requests + response bodies
+- `--all-in-room` flag on `lox on`/`lox off` — apply command to all controls in a room
+- Structured JSON error envelopes when using `-o json` (categorized error codes: `control_not_found`, `ambiguous_control`, `unauthorized`, `connection_error`, etc.)
+
+### Changed
+- `lox extensions` now queries `/data/status` instead of `LoxApp3.json` — provides richer device information including Tree branch error counts, device parent relationships, and plugin versions
+
 ### Removed
 - `lox daemon` — automation daemon (WebSocket/polling rule engine)
 - `lox automation` — automation rule management

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -8,7 +8,34 @@ lox get "Temperatur" -r "Schlafzimmer"
 lox get "Temperatur [OG Schlafzimmer]"
 ```
 
-Global flags: `-o`/`--output json|csv|table`, `-q`/`--quiet`, `--no-color` (also respects `NO_COLOR` env var), `--no-header`
+Global flags: `-o`/`--output json|csv|table`, `-q`/`--quiet`, `--no-color` (also respects `NO_COLOR` env var), `--no-header`, `-v`/`--verbose` (request logging), `--dry-run`, `--non-interactive`, `--trace-id`
+
+---
+
+## Verbose & Dry-Run
+
+```bash
+lox -v ls                              # show HTTP requests
+lox -vv get "Temperatur"               # show requests + response bodies
+lox --dry-run on "Licht Wohnzimmer"    # preview without executing
+lox --dry-run on "Licht" -o json       # dry-run returns JSON envelope
+lox --non-interactive reboot           # fail instead of prompting (implied by -o json)
+lox --trace-id "abc-123" on "Licht"    # correlation ID for agent tracing
+```
+
+`--dry-run` validates and resolves inputs without sending commands. With `-o json`, it returns a structured envelope:
+```json
+{
+  "ok": true,
+  "dry_run": true,
+  "would_execute": {
+    "uuid": "1d8af56e-...",
+    "command": "on",
+    "control": "Licht Wohnzimmer",
+    "room": "Wohnzimmer"
+  }
+}
+```
 
 ---
 
@@ -59,6 +86,13 @@ lox modes                             # operating modes
 lox extensions                        # connected extensions and devices
 lox discover                          # find Miniservers on local network (UDP)
 lox discover --timeout 5
+
+lox health                            # device health dashboard (battery, signal, offline)
+lox health --type tree                # filter by device type (tree or air)
+lox health --problems                 # show only devices with issues
+
+lox schema                            # list all commands with metadata (for AI agents)
+lox schema blind                      # show schema for a specific command
 ```
 
 ---
@@ -68,6 +102,8 @@ lox discover --timeout 5
 ```bash
 lox on "Licht Wohnzimmer"
 lox off "Licht Wohnzimmer"
+lox on --all-in-room "Wohnzimmer"     # turn on all controls in a room
+lox off --all-in-room "Schlafzimmer"  # turn off all controls in a room
 lox light mood "Licht Wohnzimmer" plus      # next mood
 lox light mood "Licht Wohnzimmer" minus     # previous mood
 lox light mood "Licht Wohnzimmer" off       # turn off (mood 778)
@@ -237,6 +273,47 @@ lox time                               # Miniserver system date/time
 lox log                                # system log (admin only)
 lox log -n 100                         # custom line count
 ```
+
+---
+
+## Device Health
+
+```bash
+lox health                            # device health dashboard
+lox health --type tree                # filter: tree or air devices only
+lox health --problems                 # show only devices with warnings/offline
+lox health -o json                    # JSON output
+```
+
+Shows battery levels, signal strength, online/offline status, and bus errors for Tree and Air devices.
+
+---
+
+## Command Schema (AI Agents)
+
+```bash
+lox schema                            # list all commands with metadata
+lox schema blind                      # schema for a specific command
+lox schema -o json                    # JSON output for programmatic use
+```
+
+Returns command structure, arguments, subcommands, control type hints, and valid actions. Designed for AI agent discovery — agents can introspect what commands exist and what parameters they accept.
+
+---
+
+## Error Envelopes
+
+When using `-o json`, errors return structured envelopes instead of plain text:
+
+```json
+{
+  "ok": false,
+  "error": "control_not_found",
+  "message": "No control matching 'Nonexistent'"
+}
+```
+
+Error codes: `control_not_found`, `ambiguous_control`, `config_not_found`, `confirmation_required`, `unauthorized`, `forbidden`, `not_found`, `http_error`, `connection_error`, `error`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ This CLI was designed for AI agent integration. Every command:
 - Uses fuzzy name matching — agents don't need UUIDs
 - Supports `--room` flag and `[Room]` bracket syntax to resolve ambiguous names
 - Returns readable errors with suggestions
+- `--dry-run` validates without executing — preview what would happen
+- `--trace-id` correlates agent actions across logs
+- `--non-interactive` fails instead of prompting (implied by `-o json`)
+- `lox schema` lets agents discover available commands programmatically
+- Errors return structured JSON envelopes with categorized error codes
 
 **Example: give an LLM a shell tool**
 ```json
@@ -62,6 +67,15 @@ This CLI was designed for AI agent integration. Every command:
 The agent calls `lox <command>` as a shell tool and reads stdout. That's it.
 
 An agent can discover your home (`lox ls -o json`), read sensor values, control devices, and check conditions — all without any custom integration layer.
+
+**Agent-friendly workflow:**
+```bash
+lox schema -o json                    # discover available commands
+lox ls -o json                        # discover controls
+lox --dry-run on "Licht" -o json      # preview before executing
+lox --trace-id "run-42" on "Licht"    # execute with tracing
+lox health --problems -o json         # check device health
+```
 
 ---
 
@@ -143,6 +157,8 @@ lox status --energy                    # Energy dashboard
 lox config download --extract          # Download & extract Loxone Config
 lox config diff old.Loxone new.Loxone  # Compare two configs
 lox run abend                          # Run a scene
+lox health --problems                  # Device health (battery, signal, offline)
+lox schema blind                       # Command schema for AI agent discovery
 lox completions bash                   # Generate shell completions
 ```
 


### PR DESCRIPTION
## Summary
- Document `lox health` command (PR #67) and `lox schema` command (PR #69)
- Document new global flags: `--dry-run`, `--verbose`, `--non-interactive`, `--trace-id`, `--all-in-room` (PRs #60, #69)
- Document structured JSON error envelopes and `lox extensions` behavioral change (PRs #68, #69)
- Update CHANGELOG.md with all unreleased additions and changes

## Test plan
- [ ] Verify COMMANDS.md examples match actual CLI behavior
- [ ] Verify README.md agent workflow examples are accurate
- [ ] Verify CHANGELOG.md entries match merged PR contents

https://claude.ai/code/session_01J7EoCzLQ5QKWCfPg4atkTE