### PR TITLE
docs: add config gitops commands to COMMANDS, DESIGN, CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `lox config init <path>` — initialize a git repository for config version tracking (multi-Miniserver via serial subdirectories)
+- `lox config pull [--quiet]` — download config via FTP, decompress LoxCC, generate semantic diff, and git-commit with meaningful change messages
+- `lox config log [-n COUNT]` — show config change history from the git repository
+- `lox config restore <commit> --force` — restore a previous config version from git history and upload to Miniserver
 - `lox health` — device health dashboard showing battery, signal, offline status, and bus errors for Tree/Air devices (`--type tree|air`, `--problems`)
 - `lox schema` — command schema introspection for AI agent discovery; lists commands with metadata, args, and valid actions
 - `--dry-run` global flag — validates and resolves inputs without executing commands; returns structured JSON envelope with `-o json`

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -256,7 +256,18 @@ lox config upload config.zip --force   # upload to Miniserver (dangerous)
 lox config users file.Loxone           # list user accounts from config XML
 lox config devices file.Loxone         # list hardware devices (Tree/Air/Network)
 lox config diff old.Loxone new.Loxone  # compare two configs (accepts .zip or .Loxone)
+
+# Git-based config versioning
+lox config init ~/loxone-config        # initialize a git repo for config tracking
+lox config pull                        # download, decompress, diff & git-commit
+lox config pull --quiet                # cron-friendly (no output unless error)
+lox config log                         # show config change history
+lox config log -n 5                    # last 5 entries
+lox config restore abc123 --force      # restore config from git history & upload
 ```
+
+The `pull` workflow: FTP download → LoxCC decompress → semantic diff → git commit with meaningful message.
+Multi-Miniserver: each serial gets its own subdirectory in the repo.
 
 ---
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -50,6 +50,7 @@ Working. Core commands functional and tested end-to-end.
 | `lox watch` | ✅ | HTTP polling loop |
 | `lox run <scene>` | ✅ | Multi-step YAML scenes |
 | `lox log` | ⚠️ | Needs admin user |
+| `lox config init/pull/log/restore` | ✅ | Git-based config versioning |
 | `--json` output | ✅ | All commands |
 
 ---


### PR DESCRIPTION
## Summary

- Add `config init/pull/log/restore` to the **COMMANDS.md** Loxone Config section with usage examples
- Add config versioning status row to **DESIGN.md** "What Works Today" table
- Add changelog entries for the four new commands in **CHANGELOG.md** `[Unreleased]`

Follow-up to #71 which added the implementation but missed these docs.

## Test plan

- [x] Docs-only change, no code modified

https://claude.ai/code/session_01SvJgHmZTgwP8Ef3V7HULSm