### PR TITLE
Add GitHub badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # lox — Loxone Miniserver CLI
 
-**Fast, scriptable command-line interface for Loxone Miniserver.**  
+[![CI](https://github.com/discostu105/lox/actions/workflows/ci.yml/badge.svg)](https://github.com/discostu105/lox/actions/workflows/ci.yml)
+[![Release](https://github.com/discostu105/lox/actions/workflows/release.yml/badge.svg)](https://github.com/discostu105/lox/actions/workflows/release.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![Rust](https://img.shields.io/badge/Rust-1.75%2B-orange.svg?logo=rust)](https://www.rust-lang.org/)
+
+**Fast, scriptable command-line interface for Loxone Miniserver.**
 Single binary. No runtime. No cloud. Works in scripts, cron jobs, and AI agent pipelines.
 
 ---


### PR DESCRIPTION
## Summary
- Adds CI, Release, License (MIT), and Rust version badges to the top of the README
- Provides quick visual project health and metadata at a glance

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (92 tests)
- [ ] Verify badges render correctly on GitHub after merge

https://claude.ai/code/session_01Lk2nrAWYUavPbAegkT9njb