### PR TITLE
Fix CI: lower rust-version from 1.94 to 1.91

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "lox"
 version = "0.7.0"
 edition = "2024"
-rust-version = "1.94"
+rust-version = "1.91"
 description = "Loxone Miniserver CLI — control lights, blinds, and more from your terminal"
 repository = "https://github.com/discostu105/lox"
 homepage = "https://github.com/discostu105/lox"


### PR DESCRIPTION
The MSRV was set to 1.94 which isn't available as a stable toolchain
yet (stable is 1.93.1), causing CI to fail. The actual minimum required
version is 1.91 (for floor_char_boundary).

https://claude.ai/code/session_01RvUtx7zSKcgSuwBMqj6hNE