### PR TITLE
Update Rust badge to 1.91+ and add Codecov coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,8 @@ jobs:
       - name: Generate coverage
         run: cargo tarpaulin --out xml --output-dir coverage
 
-      - name: Upload coverage
-        uses: actions/upload-artifact@v4
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v4
         with:
-          name: coverage-report
-          path: coverage/cobertura.xml
+          files: coverage/cobertura.xml
+          fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Release](https://github.com/discostu105/lox/actions/workflows/release.yml/badge.svg)](https://github.com/discostu105/lox/actions/workflows/release.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![Rust](https://img.shields.io/badge/Rust-1.91%2B-orange.svg?logo=rust)](https://www.rust-lang.org/)
+[![codecov](https://codecov.io/gh/discostu105/lox/branch/main/graph/badge.svg)](https://codecov.io/gh/discostu105/lox)
 
 **Fast, scriptable command-line interface for Loxone Miniserver.**
 Single binary. No runtime. No cloud. Works in scripts, cron jobs, and AI agent pipelines.


### PR DESCRIPTION
## Summary
- Update the Rust version badge and requirements text from 1.75+ to 1.91+ to match `Cargo.toml`
- Add Codecov integration: replace artifact-only coverage upload with `codecov/codecov-action@v4`
- Add a Codecov coverage badge to the README

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, verify Codecov badge populates on the README

https://claude.ai/code/session_01RvUtx7zSKcgSuwBMqj6hNE