### PR TITLE
Add CODECOV_TOKEN secret to Codecov coverage upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,4 +64,5 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           files: coverage/cobertura.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false


### PR DESCRIPTION
The codecov-action@v4 requires an authentication token for uploads.
Without it, coverage data cannot be sent to Codecov from CI.

https://claude.ai/code/session_01SFJVujVioNxnMiwEnJxJKa