### PR TITLE
Fix 5 bugs: integer code masking, token panic, missing HTTP status checks, ws:// Host header, URL redaction

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -42,12 +42,22 @@ pub(crate) fn redact_url(url: &str) -> String {
     } else {
         url.to_string()
     };
-    // Redact all occurrences of known sensitive query params
+    // Redact all occurrences of known sensitive query params.
+    // Only match whole parameter names (preceded by '?' or '&') to avoid
+    // false positives like "passthrough=" matching the "pass=" pattern.
     for param in &["token", "key", "pass", "password", "autht"] {
         let pattern = format!("{}=", param);
         let mut search_from = 0;
         while let Some(idx) = result[search_from..].find(&pattern) {
             let abs_idx = search_from + idx;
+            // Ensure this is a whole query parameter name, not a substring
+            if abs_idx > 0 {
+                let prev = result.as_bytes()[abs_idx - 1];
+                if prev != b'?' && prev != b'&' {
+                    search_from = abs_idx + pattern.len();
+                    continue;
+                }
+            }
             let start = abs_idx + pattern.len();
             let end = result[start..]
                 .find('&')
@@ -192,16 +202,24 @@ impl LoxClient {
         }
         self.request_with_retry(|| {
             let resp = self.apply_auth(self.client.get(&url)).send()?;
+            let status = resp.status();
             if verbose() >= 1 {
                 eprintln!(
                     "  → {} {}",
-                    resp.status().as_u16(),
-                    resp.status().canonical_reason().unwrap_or("")
+                    status.as_u16(),
+                    status.canonical_reason().unwrap_or("")
                 );
             }
             let body = resp.text()?;
             if verbose() >= 2 {
                 log_body(&body);
+            }
+            if !status.is_success() {
+                return Err(HttpStatusError {
+                    status: status.as_u16(),
+                    path: path.to_string(),
+                }
+                .into());
             }
             Ok(body)
         })
@@ -214,12 +232,20 @@ impl LoxClient {
         }
         self.request_with_retry(|| {
             let resp = self.apply_auth(self.client.get(&url)).send()?;
+            let status = resp.status();
             if verbose() >= 1 {
                 eprintln!(
                     "  → {} {}",
-                    resp.status().as_u16(),
-                    resp.status().canonical_reason().unwrap_or("")
+                    status.as_u16(),
+                    status.canonical_reason().unwrap_or("")
                 );
+            }
+            if !status.is_success() {
+                return Err(HttpStatusError {
+                    status: status.as_u16(),
+                    path: path.to_string(),
+                }
+                .into());
             }
             if verbose() >= 2 {
                 let text = resp.text()?;

--- a/src/commands/config_cmd.rs
+++ b/src/commands/config_cmd.rs
@@ -258,11 +258,15 @@ pub fn cmd_token(ctx: &RunContext, action: TokenCmd) -> Result<()> {
                     .unwrap()
                     .as_secs();
                 let days_left = ts.valid_until.saturating_sub(now) / 86400;
-                println!(
-                    "Token: {}...{}",
-                    &ts.token[..8],
-                    &ts.token[ts.token.len() - 4..]
-                );
+                if ts.token.len() >= 12 {
+                    println!(
+                        "Token: {}...{}",
+                        &ts.token[..8],
+                        &ts.token[ts.token.len() - 4..]
+                    );
+                } else {
+                    println!("Token: {}", ts.token);
+                }
                 if ts.is_valid() {
                     println!("Status: ✓ valid ({} days remaining)", days_left);
                 } else {

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -657,8 +657,12 @@ async fn ws_read_text_value(
                 let code = v
                     .pointer("/LL/Code")
                     .or_else(|| v.pointer("/LL/code"))
-                    .and_then(|c| c.as_str().or_else(|| c.as_i64().map(|_| "200")))
-                    .unwrap_or("0");
+                    .and_then(|c| {
+                        c.as_str()
+                            .map(|s| s.to_string())
+                            .or_else(|| c.as_i64().map(|n| n.to_string()))
+                    })
+                    .unwrap_or_else(|| "0".to_string());
                 if code == "200" {
                     let val = v.pointer("/LL/value").unwrap_or(&Value::Null);
                     return if val.is_string() {
@@ -693,8 +697,12 @@ async fn ws_expect_code_200(
                 let code = v
                     .pointer("/LL/Code")
                     .or_else(|| v.pointer("/LL/code"))
-                    .and_then(|c| c.as_str().or_else(|| c.as_i64().map(|_| "200")))
-                    .unwrap_or("0");
+                    .and_then(|c| {
+                        c.as_str()
+                            .map(|s| s.to_string())
+                            .or_else(|| c.as_i64().map(|n| n.to_string()))
+                    })
+                    .unwrap_or_else(|| "0".to_string());
                 if code == "200" {
                     return Ok(());
                 }

--- a/src/ws.rs
+++ b/src/ws.rs
@@ -102,7 +102,7 @@ impl LoxWsClient {
             .header("Authorization", format!("Basic {}", basic))
             .header(
                 "Host",
-                url.split("wss://")
+                url.split("://")
                     .nth(1)
                     .unwrap_or("")
                     .split('/')


### PR DESCRIPTION
- stream.rs: Fix ws_read_text_value/ws_expect_code_200 mapping ANY integer
  response code to "200", masking real error codes like 401/500
- config_cmd.rs: Prevent panic on tokens shorter than 12 chars when
  displaying truncated token in `token info`
- client.rs: Add HTTP status code checks to get_text() and get_json()
  (get_bytes() already had them), preventing silent acceptance of error pages
- ws.rs: Fix Host header extraction using "wss://" split that produces empty
  header for ws:// URLs; now uses "://" to handle both schemes
- client.rs: Fix redact_url false-positives where "pass=" pattern matched
  inside longer param names like "passthrough="; now checks for ? or & prefix

https://claude.ai/code/session_0186WmaE9Cb7T1Nhae9cV3Gu