### PR TITLE
Add GitHub Pages documentation site

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,44 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./docs
+          destination: ./_site
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "jekyll-remote-theme"
+gem "just-the-docs"

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,38 @@
+title: lox
+description: Loxone Miniserver CLI — control lights, blinds, and more from your terminal
+remote_theme: just-the-docs/just-the-docs@v0.10.0
+url: https://discostu105.github.io
+baseurl: /lox
+
+aux_links:
+  GitHub: https://github.com/discostu105/lox
+
+nav_enabled: true
+
+heading_anchors: true
+
+back_to_top: true
+back_to_top_text: "Back to top"
+
+footer_content: "MIT License. <a href=\"https://github.com/discostu105/lox\">View on GitHub</a>."
+
+color_scheme: dark
+
+exclude:
+  - api-research.md
+  - autopilot-design.md
+  - design-backup.md
+  - design-backup-inspect.md
+  - loxone-config-research.md
+  - plan.md
+
+callouts:
+  warning:
+    title: Warning
+    color: red
+  note:
+    title: Note
+    color: blue
+  tip:
+    title: Tip
+    color: green

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,114 @@
+---
+title: Architecture
+layout: default
+nav_order: 5
+---
+
+# Architecture
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+## Overview
+
+`lox` is a single static Rust binary (~4MB). TLS is handled by rustls (no OpenSSL dependency). Self-signed certificates from Miniservers are accepted by default.
+
+## Source structure
+
+| File | Purpose |
+|:-----|:--------|
+| `src/main.rs` | CLI entry point, clap argument definitions, command dispatch |
+| `src/commands/control.rs` | Control commands (on, off, blind, light, gate, thermostat, etc.) |
+| `src/commands/inspect.rs` | Inspection commands (ls, get, info, watch, stream, etc.) |
+| `src/commands/system.rs` | System commands (status, log, health, extensions, etc.) |
+| `src/commands/config_cmd.rs` | Config management commands (download, diff, git versioning) |
+| `src/client.rs` | `LoxClient` — HTTP client, control resolution, structure cache |
+| `src/config.rs` | `Config` struct — loads/saves `~/.lox/config.yaml` |
+| `src/stream.rs` | Real-time WebSocket state streaming |
+| `src/otel.rs` | OpenTelemetry metrics, logs, and traces export |
+| `src/gitops.rs` | Git-based config versioning (init, pull, log, restore) |
+| `src/scene.rs` | Scene loading/listing from YAML |
+| `src/ws.rs` | `LoxWsClient` — WebSocket for token auth key exchange |
+| `src/token.rs` | Token auth flow (RSA + AES encryption, HMAC hashing) |
+| `src/ftp.rs` | FTP client for config download |
+| `src/loxcc.rs` | LoxCC format decompression (proprietary config format) |
+| `src/loxone_xml.rs` | Loxone XML parsing |
+
+## Control resolution
+
+The `LoxClient::resolve_with_room` function resolves human-readable names to control UUIDs using fuzzy substring matching against the structure cache.
+
+**Resolution order:**
+1. Alias lookup (from config)
+2. Exact UUID match
+3. Bracket room qualifier (`"Name [Room]"`)
+4. `--room` flag filtering
+5. Fuzzy substring match
+
+Ambiguous matches produce an error with a list of candidates.
+
+## Structure cache
+
+The Miniserver's `LoxApp3.json` (~150KB) is cached at `~/.lox/cache/structure.json` with a 24-hour TTL. All commands that need control UUIDs load this cache first.
+
+```bash
+lox cache info      # check cache status
+lox cache refresh   # force re-fetch
+```
+
+## Mixed sync/async runtime
+
+CLI commands use `reqwest::blocking` for synchronous HTTP. The `#[tokio::main]` attribute on `main()` exists because `lox token fetch` needs async WebSocket support for the RSA/AES key exchange handshake. The blocking reqwest client spawns its own thread pool, so both modes coexist.
+
+## Token authentication
+
+The token auth flow:
+
+1. Fetch RSA public key from Miniserver
+2. Generate random AES session key
+3. Encrypt AES key with RSA public key
+4. Send encrypted credentials via WebSocket
+5. Receive encrypted token, decrypt with AES key
+6. Store token at `~/.lox/token.json` (valid ~20 days)
+7. Token is used for all subsequent HTTP requests via HMAC hashing
+
+## User data layout
+
+```
+~/.lox/
+  config.yaml          # Host, credentials, serial, aliases
+  token.json           # Token auth (optional, valid ~20 days)
+  cache/
+    structure.json     # LoxApp3.json cache (24h TTL, ~150KB)
+  scenes/*.yaml        # Multi-step scene definitions
+```
+
+## TLS
+
+Self-signed certificates are accepted (`danger_accept_invalid_certs(true)`) since Miniservers use self-signed certs. When `serial` is set in config, `Config::tls_host()` generates the DynDNS hostname for valid certificate matching.
+
+## Loxone HTTP API
+
+The CLI communicates with the Miniserver via its HTTP API:
+
+| Endpoint | Purpose |
+|:---------|:--------|
+| `GET /data/LoxApp3.json` | Full structure (controls, rooms, categories) |
+| `GET /jdev/sps/io/{uuid}/{cmd}` | Send command to control |
+| `GET /dev/sps/io/{uuid}/all` | All state outputs for a control (XML) |
+| `GET /dev/sps/io/{name}/state` | Input state by name |
+| `GET /dev/sys/heap` | System status |
+| `GET /jdev/sys/lastcpu` | Diagnostics |
+| `GET /jdev/cfg/ip` | Network configuration |
+| `GET /binstatisticdata/{uuid}/{period}` | Binary statistics data |
+| `GET /data/weatheru.bin` | Binary weather data |
+| `GET /dev/fsget/{path}` | Filesystem access |
+| `WSS /ws/rfc6455` | WebSocket (token auth) |
+| `UDP :7070` | Miniserver discovery |
+| `HTTP :7091/zone/{n}/{cmd}` | Music server (unofficial) |

--- a/docs/commands/configuration.md
+++ b/docs/commands/configuration.md
@@ -1,0 +1,141 @@
+---
+title: Configuration
+layout: default
+parent: Command Reference
+nav_order: 4
+---
+
+# Configuration Commands
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+## Setup
+
+```bash
+lox setup set --host https://192.168.1.100 --user admin --pass secret
+lox setup set --serial YOUR_SERIAL         # enables correct TLS hostname
+lox setup set --verify-ssl                 # enable cert verification
+lox setup set --no-verify-ssl              # disable (default, self-signed)
+lox setup show                             # show config (password redacted)
+```
+
+All fields support environment variables: `LOX_HOST`, `LOX_USER`, `LOX_PASS`, `LOX_SERIAL`.
+
+---
+
+## Aliases
+
+```bash
+lox alias add wz "1d8af56e-036e-e9ad-ffffed57184a04d2"
+lox alias remove wz
+lox alias ls
+```
+
+Then use directly: `lox on wz`, `lox get wz`
+
+---
+
+## Cache
+
+The structure cache (`~/.lox/cache/structure.json`) stores the Miniserver's LoxApp3.json with a 24-hour TTL.
+
+```bash
+lox cache info               # show cache age and path
+lox cache check              # check if cache is current
+lox cache refresh            # force re-fetch
+lox cache clear              # delete local cache
+```
+
+---
+
+## Token auth
+
+More secure than Basic Auth. Tokens are valid ~20 days.
+
+```bash
+lox token fetch              # fetch and save new token
+lox token info               # show token status
+lox token check              # verify token on Miniserver
+lox token refresh            # extend validity
+lox token revoke             # revoke token on Miniserver
+lox token clear              # delete local token file
+```
+
+The token auth flow uses RSA+AES key exchange via WebSocket. Once acquired, the token is automatically used for all HTTP requests.
+
+---
+
+## Scenes
+
+```bash
+lox scene ls                 # list all scenes
+lox scene show abend         # print YAML definition
+lox scene new abend          # create empty scene file
+```
+
+Scene files are stored in `~/.lox/scenes/*.yaml`. See the [Scenes guide](/lox/guides/scenes) for details.
+
+---
+
+## Loxone Config management
+
+Download, inspect, and manage Loxone Config files:
+
+```bash
+lox config download                       # download latest config ZIP via FTP
+lox config download --extract             # download + decompress to .Loxone XML
+lox config download --save-as config.zip  # custom output filename
+lox config ls                             # list available configs
+lox config extract config.zip             # decompress LoxCC to .Loxone XML
+lox config extract config.zip --save-as out.Loxone
+lox config upload config.zip --force      # upload to Miniserver
+lox config users file.Loxone              # list user accounts
+lox config devices file.Loxone            # list hardware devices
+lox config diff old.Loxone new.Loxone     # compare two configs
+```
+
+### Git-based config versioning
+
+Track configuration changes in a git repository:
+
+```bash
+lox config init ~/loxone-config           # initialize git repo
+lox config pull                           # download, diff, and git-commit
+lox config pull --quiet                   # cron-friendly
+lox config log                            # show change history
+lox config log -n 5                       # last 5 entries
+lox config restore abc123 --force         # restore from git history
+```
+
+See the [Config Versioning guide](/lox/guides/config-versioning) for the full workflow.
+
+---
+
+## Shell completions
+
+```bash
+lox completions bash                      # generate bash completions
+lox completions zsh                       # generate zsh completions
+lox completions fish                      # generate fish completions
+lox completions powershell                # generate PowerShell completions
+lox completions --install                 # auto-detect and install
+```
+
+---
+
+## Command schema
+
+For AI agent integration — discover available commands programmatically:
+
+```bash
+lox schema                                # list all commands with metadata
+lox schema blind                          # schema for a specific command
+lox schema -o json                        # JSON for programmatic use
+```

--- a/docs/commands/controls.md
+++ b/docs/commands/controls.md
@@ -1,0 +1,220 @@
+---
+title: Controls
+layout: default
+parent: Command Reference
+nav_order: 1
+---
+
+# Control Commands
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+## On / Off
+
+Turn controls on or off by name, UUID, or alias.
+
+```bash
+lox on "Licht Wohnzimmer"
+lox off "Licht Wohnzimmer"
+```
+
+Apply to all controls in a room:
+
+```bash
+lox on --all-in-room "Wohnzimmer"
+lox off --all-in-room "Schlafzimmer"
+```
+
+| Flag | Description |
+|:-----|:------------|
+| `-r`, `--room` | Disambiguate by room name |
+| `--all-in-room` | Apply to all controls in the specified room |
+
+---
+
+## Lights
+
+### Moods
+
+```bash
+lox light mood "Licht Wohnzimmer" plus      # next mood
+lox light mood "Licht Wohnzimmer" minus     # previous mood
+lox light mood "Licht Wohnzimmer" off       # all off (mood 778)
+lox light mood "Licht Wohnzimmer" 704       # set by mood ID
+```
+
+### Dimmer
+
+```bash
+lox light dim "Stehlampe" 75               # set dimmer 0-100%
+```
+
+### Color
+
+```bash
+lox light color "LED Strip" "#FF0000"              # hex RGB
+lox light color "LED Strip" "hsv(120,100,100)"     # HSV
+```
+
+---
+
+## Blinds
+
+```bash
+lox blind "Beschattung Sud" up
+lox blind "Beschattung Sud" down
+lox blind "Beschattung Sud" stop
+lox blind "Beschattung Sud" pos 50          # position 0-100%
+lox blind "Beschattung Sud" shade           # automatic shading
+lox blind "Beschattung Sud" full-up
+lox blind "Beschattung Sud" full-down
+```
+
+| Action | Description |
+|:-------|:------------|
+| `up` | Move blind up |
+| `down` | Move blind down |
+| `stop` | Stop movement |
+| `pos <0-100>` | Set exact position (0=open, 100=closed) |
+| `shade` | Automatic shading position |
+| `full-up` | Move fully up |
+| `full-down` | Move fully down |
+
+---
+
+## Gates
+
+```bash
+lox gate "Garagentor" open
+lox gate "Garagentor" close
+lox gate "Garagentor" stop
+```
+
+---
+
+## Thermostats
+
+```bash
+lox thermostat "Heizung" temp 22.5              # set comfort temperature
+lox thermostat "Heizung" mode auto               # auto | manual | comfort | eco
+lox thermostat "Heizung" override 24 120         # override 24C for 120 minutes
+lox thermostat "Heizung"                         # show current state
+```
+
+---
+
+## Alarm
+
+```bash
+lox alarm "Alarmanlage" arm
+lox alarm "Alarmanlage" arm --no-motion    # arm without motion detection
+lox alarm "Alarmanlage" arm-home
+lox alarm "Alarmanlage" disarm
+lox alarm "Alarmanlage" quit               # acknowledge / silence
+```
+
+| Flag | Description |
+|:-----|:------------|
+| `--no-motion` | Arm without motion detection |
+| `--code` | Provide access code |
+| `-r`, `--room` | Disambiguate by room |
+
+---
+
+## Door locks
+
+```bash
+lox door "Haustur" lock
+lox door "Haustur" unlock
+lox door "Haustur" open        # open (e.g. electric strike)
+```
+
+---
+
+## Intercom
+
+```bash
+lox intercom "Turklingel" answer
+lox intercom "Turklingel" hangup
+lox intercom "Turklingel" open
+```
+
+---
+
+## EV Charger
+
+```bash
+lox charger "Wallbox" start
+lox charger "Wallbox" stop
+lox charger "Wallbox" pause
+lox charger "Wallbox" start --limit 16     # set current limit
+```
+
+---
+
+## Analog / Virtual inputs
+
+```bash
+lox input set "Sollwert Heizung" 21.5
+lox input set "Sollwert Heizung" 21.5 -r "Wohnzimmer"
+lox input pulse "Taster"
+```
+
+---
+
+## Music server
+
+```bash
+lox music play                    # play zone 1
+lox music pause 2                 # pause zone 2
+lox music stop
+lox music volume 50               # volume 0-100
+lox music next
+lox music prev
+lox music mute
+lox music unmute
+```
+
+All music commands accept an optional zone number (default: 1).
+
+---
+
+## Lock / Unlock controls
+
+Administrative lock to prevent changes:
+
+```bash
+lox lock "Heizung" --reason "Wartung"
+lox unlock "Heizung"
+```
+
+---
+
+## Raw commands
+
+Send any command directly to a control by UUID:
+
+```bash
+lox send <uuid> <command>
+lox send <uuid> <command> --secured <hash>
+```
+
+---
+
+## Scenes
+
+Run multi-step automation scenes:
+
+```bash
+lox run abend                    # run a scene
+lox run abend --dry-run          # preview without executing
+```
+
+See the [Scenes guide](/lox/guides/scenes) for defining scenes.

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -1,0 +1,63 @@
+---
+title: Command Reference
+layout: default
+nav_order: 3
+has_children: true
+---
+
+# Command Reference
+{: .no_toc }
+
+All commands support these global flags:
+{: .fs-5 .fw-300 }
+
+| Flag | Description |
+|:-----|:------------|
+| `-o`, `--output` | Output format: `table` (default), `json`, `csv` |
+| `-q`, `--quiet` | Suppress non-essential output |
+| `--no-color` | Disable colored output (also respects `NO_COLOR` env var) |
+| `--no-header` | Suppress table headers |
+| `-v`, `--verbose` | Verbose logging (`-v` HTTP requests, `-vv` + response bodies) |
+| `--dry-run` | Validate and resolve without executing |
+| `--non-interactive` | Fail instead of prompting (implied by `-o json`) |
+| `--trace-id` | Correlation ID for agent tracing |
+
+## Control resolution
+
+Controls can be referenced by **name** (fuzzy matched), **UUID**, or **alias**.
+
+When multiple controls share the same name, disambiguate with:
+
+```bash
+# --room flag
+lox get "Temperatur" --room "Schlafzimmer"
+
+# Bracket syntax
+lox get "Temperatur [OG Schlafzimmer]"
+```
+
+Resolution order: alias > exact UUID > bracket room qualifier > `--room` flag > fuzzy substring.
+
+## Dry-run mode
+
+Preview what a command would do without executing:
+
+```bash
+lox --dry-run on "Licht Wohnzimmer"
+lox --dry-run on "Licht" -o json
+```
+
+JSON dry-run output:
+
+```json
+{
+  "ok": true,
+  "dry_run": true,
+  "would_execute": {
+    "uuid": "1d8af56e-...",
+    "command": "on",
+    "control": "Licht Wohnzimmer",
+    "room": "Wohnzimmer"
+  }
+}
+```

--- a/docs/commands/inspection.md
+++ b/docs/commands/inspection.md
@@ -1,0 +1,180 @@
+---
+title: Inspection
+layout: default
+parent: Command Reference
+nav_order: 2
+---
+
+# Inspection Commands
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+## List controls
+
+```bash
+lox ls                                 # all controls
+lox ls -t Jalousie                     # filter by type
+lox ls -r "Wohnzimmer"                 # filter by room
+lox ls -c "Beleuchtung"               # filter by category
+lox ls -f                              # only favorites
+lox ls --values                        # include live values (slower)
+lox ls -o json                         # JSON output
+```
+
+| Flag | Description |
+|:-----|:------------|
+| `-t`, `--type` | Filter by control type |
+| `-r`, `--room` | Filter by room name |
+| `-c`, `--cat` | Filter by category |
+| `-f`, `--favorites` | Only show favorites |
+| `--values` | Include live state values (requires one HTTP request per control) |
+
+---
+
+## Get control state
+
+```bash
+lox get "Licht Wohnzimmer"
+lox get "Temperatur" --room "Schlafzimmer"
+lox get "Temperatur [OG Kinderzimmer]"
+```
+
+Returns all state outputs for the control.
+
+---
+
+## Control info
+
+```bash
+lox info "Licht Wohnzimmer"
+```
+
+Shows detailed information: sub-controls, all state keys, moods (for light controllers), flags, and type metadata.
+
+---
+
+## Watch state changes
+
+Poll a control's state and print changes:
+
+```bash
+lox watch "Temperatur"
+lox watch "Temperatur" -i 5           # poll every 5 seconds
+```
+
+| Flag | Description |
+|:-----|:------------|
+| `-i`, `--interval` | Poll interval in seconds (default: 2) |
+
+Press Ctrl+C to stop.
+
+---
+
+## Stream real-time changes
+
+Stream state changes via WebSocket (more efficient than polling):
+
+```bash
+lox stream                             # stream all changes
+lox stream --room "Kitchen"            # filter by room
+lox stream --type LightControllerV2    # filter by type
+lox stream --control "Kitchen Light"   # filter by control name
+lox stream --initial                   # include initial state snapshot
+lox stream -o json                     # NDJSON output
+```
+
+| Flag | Description |
+|:-----|:------------|
+| `-t`, `--type` | Filter by control type |
+| `-r`, `--room` | Filter by room |
+| `-c`, `--control` | Filter by control name |
+| `--initial` | Include initial state snapshot |
+
+---
+
+## Conditional checks
+
+Check a control's state value. Returns exit code 0 (true) or 1 (false):
+
+```bash
+lox if "Temperatur Aussen" gt 25
+lox if "Schalter" eq 1 && lox on "Licht"
+```
+
+Operators: `eq`, `ne`, `gt`, `ge`, `lt`, `le`
+
+Useful for scripting conditional automation:
+
+```bash
+# Close blinds if temperature exceeds 28
+lox if "Temperatur Aussen" gt 28 && lox blind "Beschattung Sud" pos 70
+```
+
+---
+
+## Rooms & Categories
+
+```bash
+lox rooms                             # list all rooms
+lox categories                        # list all categories
+lox globals                           # global states (operating mode, sunrise, etc.)
+lox modes                             # operating modes
+```
+
+---
+
+## Sensors
+
+```bash
+lox sensors                           # all sensor readings
+lox sensors --type temperature        # temperature sensors only
+lox sensors --type door-window        # door/window sensors
+lox sensors --type motion             # motion sensors
+lox sensors --type smoke              # smoke detectors
+lox sensors -r "Wohnzimmer"          # filter by room
+```
+
+---
+
+## Energy
+
+```bash
+lox energy                            # show energy meter readings
+lox energy -r "Keller"               # filter by room
+```
+
+---
+
+## Weather
+
+```bash
+lox weather                           # current weather data
+lox weather --forecast                # 7-day forecast
+```
+
+---
+
+## Statistics & History
+
+```bash
+lox stats                             # controls with statistics enabled
+lox history "Temperatur" --month 2025-01
+lox history "Temperatur" --day 2025-01-15
+lox history "Temperatur" -o csv       # CSV output for spreadsheets
+```
+
+---
+
+## Autopilot rules
+
+```bash
+lox autopilot ls                      # list all automatic rules
+lox autopilot state "Rule Name"       # show when a rule last fired
+```

--- a/docs/commands/system.md
+++ b/docs/commands/system.md
@@ -1,0 +1,125 @@
+---
+title: System
+layout: default
+parent: Command Reference
+nav_order: 3
+---
+
+# System Commands
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+## Status
+
+```bash
+lox status                   # firmware, PLC state, memory
+lox status --diag            # CPU, tasks, context switches, SD card
+lox status --net             # network config (IP, MAC, DNS, DHCP, NTP)
+lox status --bus             # CAN bus statistics
+lox status --lan             # LAN packet statistics
+lox status --all             # all diagnostic sections
+lox status --energy          # energy dashboard
+```
+
+| Flag | Description |
+|:-----|:------------|
+| `--diag` | CPU, tasks, context switches, SD card test |
+| `--net` | Network configuration (IP, MAC, DNS, DHCP, NTP) |
+| `--bus` | CAN bus statistics |
+| `--lan` | LAN packet statistics |
+| `--all` | All diagnostic sections |
+| `--energy` | Energy meter dashboard |
+
+---
+
+## System log
+
+```bash
+lox log                      # last 50 lines
+lox log -n 100               # last 100 lines
+```
+
+Requires admin user credentials.
+
+---
+
+## System time
+
+```bash
+lox time                     # show Miniserver date and time
+```
+
+---
+
+## Discover
+
+Find Miniservers on the local network via UDP broadcast:
+
+```bash
+lox discover
+lox discover --timeout 5     # custom timeout in seconds
+```
+
+---
+
+## Extensions
+
+```bash
+lox extensions               # list connected extensions and devices
+```
+
+Shows Tree extensions, Air devices, and other connected hardware with serial numbers, versions, and parent relationships.
+
+---
+
+## Device health
+
+```bash
+lox health                   # full device health dashboard
+lox health --type tree       # filter: tree devices only
+lox health --type air        # filter: air devices only
+lox health --problems        # show only devices with issues
+lox health -o json           # JSON output
+```
+
+Shows battery levels, signal strength, online/offline status, and bus errors for Tree and Air devices.
+
+---
+
+## Firmware updates
+
+```bash
+lox update check             # check for available updates
+lox update install --yes     # install update (requires --yes)
+```
+
+---
+
+## Reboot
+
+```bash
+lox reboot --yes             # reboot Miniserver (requires --yes)
+```
+
+{: .warning }
+The `reboot` and `update install` commands affect your live system. Always have a backup.
+
+---
+
+## Filesystem
+
+Browse and download files from the Miniserver:
+
+```bash
+lox files ls /               # list root directory
+lox files ls /log            # list log directory
+lox files get /log/def.log   # download a file
+lox files get /log/def.log --save-as local.log
+```

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,72 @@
+---
+title: Contributing
+layout: default
+nav_order: 6
+---
+
+# Contributing
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+## Development setup
+
+```bash
+git clone https://github.com/discostu105/lox
+cd lox
+cargo build
+cargo test
+```
+
+No live Miniserver is needed for development. All unit tests use pure functions or mocked data.
+
+## Build commands
+
+```bash
+cargo build              # debug build
+cargo build --release    # production binary (~4MB)
+cargo test               # run all tests
+cargo clippy -- -D warnings  # lint (warnings are errors)
+cargo fmt --check        # check formatting
+```
+
+## Pre-push checklist
+
+All four checks must pass before pushing (mirrors CI):
+
+```bash
+cargo fmt --check
+cargo clippy -- -D warnings
+cargo build --release
+cargo test
+```
+
+## Manual testing
+
+To test against a real Miniserver:
+
+1. Loxone Miniserver (Gen 1 or Gen 2) on your local network
+2. Configure credentials: `lox setup set --host ... --user ... --pass ...`
+3. Verify: `lox status`
+
+## Pull request process
+
+- One feature or fix per PR
+- Tests expected for new logic
+- Run `cargo fmt` and `cargo clippy` before submitting
+- Update `CHANGELOG.md` under `[Unreleased]`
+
+## Project status
+
+This is an experimental project. Contributions welcome — especially for:
+
+- Testing with different Miniserver configurations
+- New control type support
+- Bug reports and fixes
+- Documentation improvements

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,182 @@
+---
+title: Getting Started
+layout: default
+nav_order: 2
+---
+
+# Getting Started
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+## Requirements
+
+- Loxone Miniserver Gen 1 or Gen 2, firmware 12.0+
+- Local network access (or DynDNS with serial configured)
+- For `lox log`: Admin user required
+
+## Installation
+
+### Homebrew (macOS / Linux)
+
+```bash
+brew tap discostu105/lox https://github.com/discostu105/lox
+brew install discostu105/lox/lox
+```
+
+### Build from source
+
+```bash
+git clone https://github.com/discostu105/lox
+cd lox
+cargo build --release
+cp target/release/lox ~/.local/bin/
+```
+
+**Build requirements:** Rust 1.91+. No OpenSSL. No runtime dependencies.
+
+The release binary is ~4MB, statically linked with rustls for TLS.
+
+---
+
+## Setup
+
+Configure your Miniserver connection:
+
+```bash
+lox setup set --host https://192.168.1.100 --user USER --pass PASS
+```
+
+With serial number for correct TLS hostname (avoids cert warnings):
+
+```bash
+lox setup set --host https://192.168.1.100 --user USER --pass PASS --serial YOUR_SERIAL
+```
+
+Verify the connection:
+
+```bash
+lox status
+```
+
+Config is stored at `~/.lox/config.yaml`.
+
+### Environment variables
+
+All config fields can be overridden via environment variables:
+
+```bash
+LOX_HOST=https://192.168.1.100 LOX_USER=admin LOX_PASS=secret lox status
+```
+
+| Variable | Config field |
+|:---------|:-------------|
+| `LOX_HOST` | `host` |
+| `LOX_USER` | `user` |
+| `LOX_PASS` | `pass` |
+| `LOX_SERIAL` | `serial` |
+
+---
+
+## Aliases
+
+Add short names for frequently-used controls:
+
+```bash
+lox alias add wz "1d8af56e-036e-e9ad-ffffed57184a04d2"
+lox alias add kueche "20236c09-0055-6e94-ffffed57184a04d2"
+lox alias ls
+```
+
+Then use them directly:
+
+```bash
+lox on wz
+lox off kueche
+```
+
+Aliases are stored in `~/.lox/config.yaml`:
+
+```yaml
+host: https://192.168.1.100
+user: admin
+pass: secret
+aliases:
+  wz: "1d8af56e-036e-e9ad-ffffed57184a04d2"
+  kueche: "20236c09-0055-6e94-ffffed57184a04d2"
+```
+
+---
+
+## Shell completions
+
+**Homebrew** installs completions automatically.
+
+**Manual install** (auto-detects your shell):
+
+```bash
+lox completions --install
+```
+
+Or generate to stdout for custom setups:
+
+```bash
+lox completions bash
+lox completions zsh
+lox completions fish
+lox completions powershell
+```
+
+Manual installation paths:
+
+```bash
+# Bash
+lox completions bash > /etc/bash_completion.d/lox
+
+# Zsh
+lox completions zsh > ~/.zfunc/_lox
+
+# Fish
+lox completions fish > ~/.config/fish/completions/lox.fish
+```
+
+---
+
+## Token authentication
+
+For better security than Basic Auth, use token authentication (valid ~20 days):
+
+```bash
+lox token fetch    # acquire and save token
+lox token info     # check token status
+lox token refresh  # extend validity
+```
+
+Once fetched, the token is used automatically for all requests. See the [Token Auth](/lox/commands/configuration#token-auth) section for all token commands.
+
+---
+
+## Discover Miniservers
+
+Find Miniservers on your local network:
+
+```bash
+lox discover
+lox discover --timeout 5
+```
+
+---
+
+## Next steps
+
+- Browse the [Command Reference](/lox/commands/) for all available commands
+- Learn about [Scenes](/lox/guides/scenes) for multi-step automation
+- Set up [Config Versioning](/lox/guides/config-versioning) for GitOps backups
+- Integrate with [AI Agents](/lox/guides/ai-agents)
+- Export data with [OpenTelemetry](/lox/guides/opentelemetry)

--- a/docs/guides/ai-agents.md
+++ b/docs/guides/ai-agents.md
@@ -1,0 +1,129 @@
+---
+title: AI Agent Integration
+layout: default
+parent: Guides
+nav_order: 2
+---
+
+# AI Agent Integration
+{: .no_toc }
+
+`lox` was designed from the ground up for AI agent integration.
+{: .fs-5 .fw-300 }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+## Design principles
+
+Every command follows these conventions for reliable agent interaction:
+
+- **Exit codes**: 0 on success, non-zero on error
+- **Structured output**: `-o json` for machine-readable output on every command
+- **Fuzzy matching**: agents don't need UUIDs — natural names work
+- **Disambiguation**: `--room` flag and `[Room]` bracket syntax resolve ambiguous names
+- **Error messages**: readable errors with suggestions for correction
+- **Dry-run**: `--dry-run` validates without executing
+- **Tracing**: `--trace-id` correlates agent actions across logs
+- **Non-interactive**: `--non-interactive` fails instead of prompting (implied by `-o json`)
+- **Schema discovery**: `lox schema` lets agents discover commands programmatically
+
+## Tool definition
+
+Give your LLM a shell tool:
+
+```json
+{
+  "name": "lox",
+  "description": "Control Loxone smart home. Use -o json for structured output.",
+  "parameters": {
+    "command": {
+      "type": "string",
+      "description": "e.g. 'on Wohnzimmer', 'blind Sudseite pos 50', 'status --energy'"
+    }
+  }
+}
+```
+
+The agent calls `lox <command>` as a shell tool and reads stdout.
+
+## Agent workflow
+
+```bash
+# 1. Discover available commands
+lox schema -o json
+
+# 2. Discover controls in the home
+lox ls -o json
+
+# 3. Preview before executing
+lox --dry-run on "Licht" -o json
+
+# 4. Execute with tracing
+lox --trace-id "run-42" on "Licht"
+
+# 5. Check device health
+lox health --problems -o json
+```
+
+## Schema discovery
+
+Agents can introspect what commands exist and what parameters they accept:
+
+```bash
+lox schema                    # list all commands
+lox schema blind              # schema for a specific command
+lox schema -o json            # JSON for programmatic use
+```
+
+## Error handling
+
+When using `-o json`, errors return structured envelopes:
+
+```json
+{
+  "ok": false,
+  "error": "control_not_found",
+  "message": "No control matching 'Nonexistent'"
+}
+```
+
+Error codes:
+
+| Code | Description |
+|:-----|:------------|
+| `control_not_found` | No control matches the name |
+| `ambiguous_control` | Multiple controls match — use `--room` to disambiguate |
+| `config_not_found` | Missing config file |
+| `confirmation_required` | Command needs `--yes` flag |
+| `unauthorized` | Invalid credentials |
+| `forbidden` | Insufficient permissions |
+| `not_found` | Resource not found |
+| `http_error` | HTTP request failed |
+| `connection_error` | Cannot reach Miniserver |
+| `error` | Generic error |
+
+## Conditional logic
+
+Use `lox if` for state-based decisions:
+
+```bash
+# Returns exit code 0 (true) or 1 (false)
+lox if "Temperatur" gt 25 && lox blind "Beschattung" pos 70
+lox if "Schalter" eq 1 && lox on "Licht"
+```
+
+## Real-time streaming
+
+For continuous monitoring, use WebSocket streaming:
+
+```bash
+lox stream -o json                       # NDJSON stream of all changes
+lox stream --room "Kitchen" -o json      # filtered by room
+lox stream --type LightControllerV2      # filtered by type
+```

--- a/docs/guides/config-versioning.md
+++ b/docs/guides/config-versioning.md
@@ -1,0 +1,101 @@
+---
+title: Config Versioning
+layout: default
+parent: Guides
+nav_order: 3
+---
+
+# Config Versioning (GitOps)
+{: .no_toc }
+
+Track Miniserver configuration changes in a git repository with automated backups and semantic diffs.
+{: .fs-5 .fw-300 }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+## Overview
+
+The `lox config` commands let you version-control your Miniserver configuration using git. Each pull downloads the config via FTP, decompresses the proprietary LoxCC format to XML, generates a semantic diff, and commits with a meaningful message.
+
+## Setup
+
+Initialize a git repository for config tracking:
+
+```bash
+lox config init ~/loxone-config
+```
+
+This creates a git repository where configs will be stored. Multi-Miniserver setups use subdirectories by serial number.
+
+## Pull workflow
+
+Download the current config, diff against the previous version, and commit:
+
+```bash
+lox config pull
+```
+
+The pull workflow:
+1. Download config ZIP via FTP
+2. Decompress LoxCC format to XML
+3. Generate semantic diff (controls/rooms/users added/removed/renamed)
+4. Commit with a meaningful message
+
+Example commit message:
+
+```
+[504F94AABBCC] Config backup 2026-03-08 18:22:56 (v42)
+
++ Added control: "Garage Light" (Switch)
+~ Light: "Licht EG" -> "Licht Erdgeschoss"
+- Removed user: "guest"
+```
+
+## View history
+
+```bash
+lox config log                  # show change history
+lox config log -n 5             # last 5 entries
+```
+
+## Restore a previous version
+
+```bash
+lox config restore abc123 --force
+```
+
+This uploads the original backup ZIP from git history to the Miniserver. No risky recompression — uses the exact file that was downloaded.
+
+{: .warning }
+Restoring a config uploads it to your live Miniserver. Always verify the commit before restoring.
+
+## Automated backups
+
+For nightly cron-based backups:
+
+```bash
+# Crontab entry
+0 2 * * * /usr/local/bin/lox config pull --quiet
+```
+
+The `--quiet` flag suppresses output unless there's an error.
+
+## Config inspection
+
+You can also download and inspect configs without git versioning:
+
+```bash
+lox config download                       # download ZIP
+lox config download --extract             # download + decompress
+lox config ls                             # list configs on Miniserver
+lox config extract config.zip             # decompress to XML
+lox config users file.Loxone              # list user accounts
+lox config devices file.Loxone            # list hardware devices
+lox config diff old.Loxone new.Loxone     # compare two configs
+```

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -1,0 +1,10 @@
+---
+title: Guides
+layout: default
+nav_order: 4
+has_children: true
+---
+
+# Guides
+
+In-depth guides for common workflows and integrations.

--- a/docs/guides/opentelemetry.md
+++ b/docs/guides/opentelemetry.md
@@ -1,0 +1,84 @@
+---
+title: OpenTelemetry
+layout: default
+parent: Guides
+nav_order: 4
+---
+
+# OpenTelemetry Export
+{: .no_toc }
+
+Push metrics, logs, and traces to any OTLP-compatible backend.
+{: .fs-5 .fw-300 }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+## Overview
+
+`lox otel` exports your smart home data via the OpenTelemetry Protocol (OTLP) to backends like Dynatrace, Datadog, Grafana Cloud, Prometheus, or any OTLP-compatible collector.
+
+### What gets exported
+
+**Metrics**: Control state gauges, system diagnostics (CPU, heap, tasks), network counters (CAN/LAN), weather data.
+
+**Logs**: State change events, text-state messages, Miniserver system log entries.
+
+**Traces**: Synthetic automation traces — correlates autopilot rule fires with temporally-close state changes.
+
+## Continuous export
+
+Run as a daemon that pushes data at regular intervals:
+
+```bash
+# Push metrics + logs + traces every 30 seconds
+lox otel serve --endpoint http://localhost:4318 --interval 30s
+
+# With auth header (Dynatrace, Datadog, etc.)
+lox otel serve --endpoint https://otlp.example.com:4318 \
+  --header "Authorization=Bearer xxx" --interval 1m
+
+# Filter by room or control type
+lox otel serve --endpoint ... --room "Kitchen" --type LightControllerV2
+
+# Metrics only (disable logs and traces)
+lox otel serve --endpoint ... --no-logs --no-traces
+
+# Metrics + logs only
+lox otel serve --endpoint ... --no-traces
+```
+
+| Flag | Description |
+|:-----|:------------|
+| `--endpoint` | OTLP endpoint URL |
+| `-i`, `--interval` | Push interval (e.g., `30s`, `1m`, `5m`) |
+| `-t`, `--type` | Filter by control type |
+| `-r`, `--room` | Filter by room |
+| `--header` | HTTP header for auth (`Key=Value`) |
+| `--delta` | Use delta temporality for counters |
+| `--no-logs` | Disable log export |
+| `--no-traces` | Disable trace export |
+
+## One-shot push
+
+For cron jobs or periodic collection:
+
+```bash
+# Push once and exit
+lox otel push --endpoint http://localhost:4318
+
+# Metrics only
+lox otel push --endpoint http://localhost:4318 --no-logs
+```
+
+## Cron example
+
+```bash
+# Push metrics every 5 minutes
+*/5 * * * * /usr/local/bin/lox otel push --endpoint http://localhost:4318
+```

--- a/docs/guides/scenes.md
+++ b/docs/guides/scenes.md
@@ -1,0 +1,80 @@
+---
+title: Scenes
+layout: default
+parent: Guides
+nav_order: 1
+---
+
+# Scenes
+{: .no_toc }
+
+Multi-step automation sequences defined as YAML files.
+{: .fs-5 .fw-300 }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+## Overview
+
+Scenes let you define a sequence of commands that run in order. They are stored as YAML files in `~/.lox/scenes/`.
+
+## Creating a scene
+
+Create a new scene file:
+
+```bash
+lox scene new abend
+```
+
+This creates `~/.lox/scenes/abend.yaml`. Edit it to define your steps:
+
+```yaml
+# ~/.lox/scenes/abend.yaml
+name: Abend
+steps:
+  - control: "Lichtsteuerung Wohnzimmer"
+    cmd: "on"
+  - control: "Beschattung Sudseite"
+    cmd: "pos 70"
+  - control: "LED Kuche"
+    cmd: "off"
+    delay_ms: 500
+```
+
+## Scene format
+
+| Field | Required | Description |
+|:------|:---------|:------------|
+| `name` | Yes | Display name for the scene |
+| `steps` | Yes | List of command steps |
+| `steps[].control` | Yes | Control name (fuzzy matched) |
+| `steps[].cmd` | Yes | Command to send |
+| `steps[].delay_ms` | No | Delay in milliseconds before this step |
+
+## Running scenes
+
+```bash
+lox run abend                    # run the scene
+lox run abend --dry-run          # preview without executing
+```
+
+The `--dry-run` flag resolves all control names and shows what would execute, without actually sending commands.
+
+## Managing scenes
+
+```bash
+lox scene ls                     # list all scenes
+lox scene show abend             # print YAML definition
+```
+
+## Tips
+
+- Controls are resolved using the same fuzzy matching as regular commands
+- Use `--room` bracket syntax in control names if needed: `"Temperatur [Schlafzimmer]"`
+- Add `delay_ms` between steps when the Miniserver needs time to process
+- Scene files can be version-controlled alongside your other dotfiles

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,89 @@
+---
+title: Home
+layout: home
+nav_order: 1
+---
+
+# lox — Loxone Miniserver CLI
+
+**Fast, scriptable command-line interface for Loxone Miniserver.**
+Single binary. No runtime. No cloud. Works in scripts, cron jobs, and AI agent pipelines.
+{: .fs-6 .fw-300 }
+
+[Get Started](/lox/getting-started){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
+[Command Reference](/lox/commands/){: .btn .fs-5 .mb-4 .mb-md-0 }
+
+---
+
+## Why this exists
+
+The Loxone app is great for everyday use — but it offers no API or scripting support for automation, CI/CD pipelines, or headless environments.
+
+`lox` gives you a proper CLI so you can:
+
+- **Script your home** — bash, Python, cron, whatever
+- **Connect AI agents** — Claude, GPT, or any LLM tool can control your home via shell commands
+- **Chain commands** — `lox if "Temperatur" gt 25 && lox blind "Sudseite" pos 80`
+- **Integrate with anything** — exit codes, JSON output, stdin/stdout
+
+```bash
+# Turn off all lights when leaving
+lox off "Licht Wohnzimmer Zentral" && lox blind "Sudseite" full-up
+
+# AI agent can call these:
+lox ls --type LightControllerV2 -o json | jq '.[].name'
+lox light mood "Wohnzimmer" off
+lox status -o json | jq '.plc_running'
+
+# Conditionally close blinds
+lox if "Temperatur Aussen" gt 28 && lox blind "Beschattung Sud" pos 70
+```
+
+---
+
+## Quick overview
+
+```bash
+lox ls                                  # List all controls
+lox get "Temperatur [Schlafzimmer]"     # Read a control's state
+lox on "Licht Wohnzimmer"              # Turn on
+lox off "Licht Wohnzimmer"             # Turn off
+lox blind "Beschattung Sud" pos 50     # Blind to 50%
+lox light mood "Licht" plus            # Next light mood
+lox thermostat "Heizung" temp 22.5     # Set temperature
+lox alarm "Alarmanlage" arm            # Arm alarm
+lox stream --room "Kitchen" -o json    # Real-time state stream
+lox status --energy                    # Energy dashboard
+lox health --problems                  # Device health
+lox config pull                        # GitOps config versioning
+```
+
+---
+
+## Supported control types
+
+| Type | Commands |
+|:-----|:---------|
+| `LightControllerV2` | `on`, `off`, `mood plus/minus/off/<id>` |
+| `Jalousie` / `CentralJalousie` | `up`, `down`, `stop`, `pos <0-100>`, `shade`, `full-up`, `full-down` |
+| `Switch` | `on`, `off`, `pulse` |
+| `Dimmer` | `dimmer <name> <0-100>` |
+| `Gate` / `CentralGate` | `gate <name> open/close/stop` |
+| `ColorPickerV2` | `color <name> #RRGGBB` or `hsv(h,s,v)` |
+| `IRoomControllerV2` | `thermostat <name> --temp/--mode/--override` |
+| `Alarm` | `alarm <name> arm/disarm/quit` |
+| `InfoOnlyAnalog` / `Meter` | `get` (read-only) |
+| Any | `send <uuid> <raw-command>`, `lock`, `unlock` |
+
+---
+
+## Performance
+
+Structure cache at `~/.lox/cache/structure.json` (24h TTL):
+
+| Operation | Cold | Warm |
+|:----------|:-----|:-----|
+| `lox on "Licht"` | ~1.2s | ~80ms |
+| `lox ls` | ~1.2s | ~80ms |
+| `lox ls --values` | ~1.2s + N reqs | slower |
+| `lox status` | ~120ms | ~120ms |


### PR DESCRIPTION
## Summary

- Adds a full Jekyll-based documentation site using the **just-the-docs** theme, deployed via GitHub Pages
- Covers all 70+ CLI commands organized into **Controls**, **Inspection**, **System**, and **Configuration** sections
- Includes guides for **Scenes**, **AI Agent Integration**, **Config Versioning (GitOps)**, and **OpenTelemetry export**
- Adds architecture overview and contributing guide
- GitHub Actions workflow (`pages.yml`) auto-deploys on pushes to `main` that touch `docs/`

## Structure

```
docs/
├── _config.yml              # Jekyll config (just-the-docs theme, dark mode)
├── Gemfile                  # Ruby dependencies
├── index.md                 # Home page
├── getting-started.md       # Install, setup, aliases, completions
├── architecture.md          # Source structure, design decisions
├── contributing.md          # Dev setup, PR process
├── commands/
│   ├── index.md             # Global flags, control resolution, dry-run
│   ├── controls.md          # on/off, lights, blinds, gates, thermostats, alarm, etc.
│   ├── inspection.md        # ls, get, watch, stream, sensors, weather, history
│   ├── system.md            # status, log, health, extensions, reboot, filesystem
│   └── configuration.md     # setup, aliases, cache, token, scenes, config mgmt
└── guides/
    ├── scenes.md            # YAML scene definitions
    ├── ai-agents.md         # LLM tool integration
    ├── config-versioning.md # GitOps config tracking
    └── opentelemetry.md     # OTLP metrics/logs/traces export
```

## Test plan

- [ ] Enable GitHub Pages in repo settings (source: GitHub Actions)
- [ ] Merge PR and verify the Pages workflow runs successfully
- [ ] Check site renders at https://discostu105.github.io/lox/
- [ ] Verify navigation works across all pages
- [ ] Verify dark theme renders correctly

https://claude.ai/code/session_01QwUWUAEXNVRj3mGgqLtvQs