### PR TITLE
docs: Add Kubernetes CronJob for config backups

### DIFF
--- a/docs/guides/config-versioning.md
+++ b/docs/guides/config-versioning.md
@@ -86,6 +86,57 @@ For nightly cron-based backups:
 
 The `--quiet` flag suppresses output unless there's an error.
 
+### Push to a remote repository
+
+Pair `lox config pull` with `git push` to keep a remote backup on GitHub:
+
+```bash
+0 2 * * * cd ~/loxone-config && /usr/local/bin/lox config pull --quiet && git push
+```
+
+### Kubernetes CronJob
+
+Run config backups as a Kubernetes CronJob that pushes changes to a GitHub repository. This is useful when you already run a k8s cluster (e.g., for `lox otel serve`).
+
+{: .note }
+The `ghcr.io/discostu105/lox` Docker image is a scratch image (no shell). The CronJob uses `alpine` and downloads the `lox` binary at runtime.
+
+**Prerequisites:**
+
+1. A GitHub repository for config history
+2. A GitHub PAT with **Contents read/write** scope
+3. A PersistentVolumeClaim for the git repo (survives between runs)
+
+**Secrets:**
+
+```bash
+# Miniserver credentials (reuse from lox otel if already deployed)
+kubectl create secret generic lox-config \
+  --from-file=config.yaml=/path/to/your/config.yaml
+
+# GitHub PAT
+kubectl create secret generic loxone-config-backup-github \
+  --from-literal=token=ghp_your_token_here
+```
+
+**Deploy:**
+
+```bash
+kubectl apply -f k8s/config-backup-cronjob.yaml
+```
+
+The CronJob ([`k8s/config-backup-cronjob.yaml`](https://github.com/discostu105/lox/blob/main/k8s/config-backup-cronjob.yaml)):
+- Runs every 6 hours (configurable via `schedule`)
+- Downloads config, generates semantic diff, commits (no-op if unchanged)
+- Pushes to your GitHub remote
+- Works on both `amd64` and `arm64` nodes
+
+**Manual trigger:**
+
+```bash
+kubectl create job --from=cronjob/loxone-config-backup loxone-config-backup-manual
+```
+
 ## Config inspection
 
 You can also download and inspect configs without git versioning:

--- a/k8s/config-backup-cronjob.yaml
+++ b/k8s/config-backup-cronjob.yaml
@@ -1,0 +1,87 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: loxone-config-backup
+spec:
+  schedule: "0 */6 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 300
+      template:
+        spec:
+          containers:
+            - name: lox
+              image: alpine:3
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  set -e
+                  apk add --no-cache git curl >/dev/null
+
+                  # Download lox binary (adjust arch: aarch64 or x86_64)
+                  ARCH=$(uname -m)
+                  case $ARCH in
+                    aarch64) LOX_ARCH="aarch64" ;;
+                    *)       LOX_ARCH="x86_64" ;;
+                  esac
+                  curl -sL -o /usr/local/bin/lox \
+                    "https://github.com/discostu105/lox/releases/latest/download/lox-linux-${LOX_ARCH}"
+                  chmod +x /usr/local/bin/lox
+
+                  # Copy lox config to writable location (lox config init writes to it)
+                  mkdir -p /root/.lox
+                  cp /tmp/lox-config/config.yaml /root/.lox/config.yaml
+
+                  REPO_DIR=/data/loxone-config
+
+                  git config --global user.email "lox-config-bot@example.com"
+                  git config --global user.name "Lox Config Bot"
+                  git config --global --add safe.directory "$REPO_DIR"
+
+                  # Init registers repo path in ~/.lox/config.yaml (idempotent)
+                  lox config init "$REPO_DIR"
+
+                  cd "$REPO_DIR"
+
+                  # Set up remote if missing
+                  if ! git remote get-url origin >/dev/null 2>&1; then
+                    git remote add origin "https://${GITHUB_TOKEN}@github.com/your-user/your-repo.git"
+                  fi
+
+                  # Download config, semantic diff, and commit (no-op if unchanged)
+                  lox config pull --quiet
+
+                  # Push to remote
+                  git push -u origin HEAD
+              env:
+                - name: GITHUB_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: loxone-config-backup-github
+                      key: token
+              volumeMounts:
+                - name: lox-config
+                  mountPath: /tmp/lox-config
+                  readOnly: true
+                - name: data
+                  mountPath: /data
+              resources:
+                requests:
+                  memory: "64Mi"
+                  cpu: "10m"
+                limits:
+                  memory: "256Mi"
+                  cpu: "200m"
+          volumes:
+            - name: lox-config
+              secret:
+                secretName: lox-config
+                items:
+                  - key: config.yaml
+                    path: config.yaml
+            - name: data
+              persistentVolumeClaim:
+                claimName: loxone-config-backup-pvc
+          restartPolicy: Never
+      backoffLimit: 3


### PR DESCRIPTION
## Summary

- Adds `k8s/config-backup-cronjob.yaml` — a ready-to-use K8s CronJob that periodically runs `lox config pull`, commits changes, and pushes to a GitHub repo
- Extends the Config Versioning guide with a Kubernetes section covering prerequisites, secrets, deployment, and manual triggers
- CronJob handles multi-arch (amd64/arm64) automatically

## Notes

- The `ghcr.io/discostu105/lox` image is scratch-based (no shell/git), so the CronJob uses `alpine` + downloads the `lox` binary at runtime
- GitHub Pages will update automatically once merged (existing `pages.yml` workflow deploys on `docs/**` changes)