### PR TITLE
fix: statically link CRT on Windows

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]
+
+[target.aarch64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]


### PR DESCRIPTION
## Summary
- Windows binary was dynamically linking `VCRUNTIME140.dll` and `api-ms-win-crt-*` DLLs, requiring the Visual C++ Redistributable to be installed
- Adds `.cargo/config.toml` with `+crt-static` for x86_64 and aarch64 Windows MSVC targets
- Makes the Windows binary truly standalone with zero runtime dependencies, matching the Linux musl builds

## Test plan
- [ ] CI passes on windows-latest
- [ ] Released binary has no dynamic CRT dependencies (`dumpbin /dependents` should show only kernel32/ntdll/etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)