### PR TITLE
docs: update GitHub Pages for ctx support

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,8 +28,9 @@ nav_order: 5
 | `src/commands/inspect.rs` | Inspection commands (ls, get, info, watch, stream, etc.) |
 | `src/commands/system.rs` | System commands (status, log, health, extensions, etc.) |
 | `src/commands/config_cmd.rs` | Config management commands (download, diff, git versioning) |
+| `src/commands/ctx.rs` | Context management (add, use, list, remove, rename, init, migrate) |
 | `src/client.rs` | `LoxClient` — HTTP client, control resolution, structure cache |
-| `src/config.rs` | `Config` struct — loads/saves `~/.lox/config.yaml` |
+| `src/config.rs` | `Config` / `GlobalConfig` — loads/saves config, multi-context support |
 | `src/stream.rs` | Real-time WebSocket state streaming |
 | `src/otel.rs` | OpenTelemetry metrics, logs, and traces export |
 | `src/gitops.rs` | Git-based config versioning (init, pull, log, restore) |
@@ -80,6 +81,7 @@ The token auth flow:
 
 ## User data layout
 
+Single-context (flat config):
 ```
 ~/.lox/
   config.yaml          # Host, credentials, serial, aliases
@@ -87,6 +89,32 @@ The token auth flow:
   cache/
     structure.json     # LoxApp3.json cache (24h TTL, ~150KB)
   scenes/*.yaml        # Multi-step scene definitions
+```
+
+Multi-context:
+```
+~/.lox/
+  config.yaml          # active_context + contexts map
+  contexts/
+    home/
+      cache/
+        structure.json # Per-context structure cache
+      token.json       # Per-context token
+    office/
+      cache/
+        structure.json
+      token.json
+  scenes/*.yaml        # Shared scene definitions
+```
+
+Project-local (auto-discovered by walking up from cwd):
+```
+./project/.lox/
+  config.yaml          # Connection settings
+  .gitignore           # Excludes secrets and cache
+  cache/
+    structure.json
+  scenes/*.yaml
 ```
 
 ## TLS

--- a/docs/commands/configuration.md
+++ b/docs/commands/configuration.md
@@ -142,9 +142,10 @@ lox --ctx office status         # run against 'office' without switching
 
 ```bash
 lox ctx init                    # create .lox/ in current directory
+lox ctx init --host https://192.168.1.100 --user admin --pass secret  # with connection details
 ```
 
-Project-local `.lox/config.yaml` is auto-discovered by walking up from cwd. Each context gets its own cache, token, and scenes directory.
+Project-local `.lox/config.yaml` is auto-discovered by walking up from cwd (like `.git`). Each context gets its own cache, token, and scenes directory. Secrets are excluded via `.lox/.gitignore`.
 
 ### Migration from flat config
 
@@ -153,6 +154,28 @@ lox ctx migrate                 # convert existing config to 'default' context
 ```
 
 Existing flat `~/.lox/config.yaml` files continue to work unchanged.
+
+### Multi-context config format
+
+```yaml
+active_context: home
+contexts:
+  home:
+    host: https://192.168.1.100
+    user: admin
+    pass: secret
+  office:
+    host: https://10.0.0.50
+    user: admin
+    pass: secret
+```
+
+### Config resolution order
+
+1. `LOX_CONFIG` env var (absolute priority)
+2. Project-local `.lox/config.yaml` (walk up from cwd)
+3. Global `~/.lox/config.yaml` (flat or multi-context)
+4. `--ctx` flag overrides context selection within global config
 
 ---
 

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -21,6 +21,7 @@ All commands support these global flags:
 | `--dry-run` | Validate and resolve without executing |
 | `--non-interactive` | Fail instead of prompting (implied by `-o json`) |
 | `--trace-id` | Correlation ID for agent tracing |
+| `--ctx <name>` | Use a specific context (overrides active context) |
 
 ## Control resolution
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -96,6 +96,24 @@ LOX_HOST=https://192.168.1.100 LOX_USER=admin LOX_PASS=secret lox status
 
 ---
 
+## Multiple Miniservers
+
+Manage multiple Miniserver connections with named contexts (similar to `kubectl config use-context`):
+
+```bash
+lox ctx add home --host https://192.168.1.100 --user admin --pass secret
+lox ctx add office --host https://10.0.0.50 --user admin --pass secret
+lox ctx use home              # switch active context
+lox ctx home                  # shortcut for `lox ctx use home`
+lox --ctx office status       # one-off command against a different context
+```
+
+Existing single-Miniserver configs continue to work. Use `lox ctx migrate` to convert a flat config to a named context when you're ready.
+
+See the [Context Management](/lox/commands/configuration#context-management) reference for all options.
+
+---
+
 ## Aliases
 
 Add short names for frequently-used controls:

--- a/docs/index.md
+++ b/docs/index.md
@@ -63,6 +63,11 @@ nav_order: 1
     <div class="feature-desc">GitOps for your Miniserver. Track config changes with semantic diffs and git history.</div>
   </div>
   <div class="feature-card">
+    <span class="feature-icon">&#128279;</span>
+    <div class="feature-title">Multi-context</div>
+    <div class="feature-desc">Manage multiple Miniservers with named contexts. Switch with <code>lox ctx use</code> or override per-command with <code>--ctx</code>.</div>
+  </div>
+  <div class="feature-card">
     <span class="feature-icon">&#9889;</span>
     <div class="feature-title">Fast</div>
     <div class="feature-desc">~80ms warm, ~1.2s cold. Structure cache with 24h TTL. Static Rust binary with zero runtime dependencies.</div>


### PR DESCRIPTION
## Summary

- Add `--ctx` to the global flags table in Command Reference index
- Add "Multiple Miniservers" section to Getting Started guide
- Add `ctx init` options, multi-context config format example, and config resolution order to Configuration reference
- Add `src/commands/ctx.rs` to Architecture source table and document multi-context data layout (per-context cache/token directories, project-local config)
- Add "Multi-context" feature card to the docs landing page

## Test plan

- [ ] Verify GitHub Pages renders correctly after merge
- [ ] Check all internal links resolve (context management anchor, configuration reference)
- [ ] Confirm no regressions in existing docs content

https://claude.ai/code/session_01VBkrLfuydsUdyUJg4B5VWk